### PR TITLE
[IMP] Backport to 8.0 from 9.0

### DIFF
--- a/operating_unit/__openerp__.py
+++ b/operating_unit/__openerp__.py
@@ -8,7 +8,7 @@
     "name": "Operating Unit",
     "summary": "An operating unit (OU) is an organizational entity part of a "
                "company",
-    "version": "9.0.1.0.0",
+    "version": "8.0.1.0.0",
     "author": "Eficent Business and IT Consulting Services S.L., "
               "Serpent Consulting Services Pvt. Ltd.,"
               "Odoo Community Association (OCA)",


### PR DESCRIPTION
This is the backport to 8.0 of module 'operating_unit' from 9.0. Note that the module was approved for 9.0 here: https://github.com/OCA/operating-unit/pull/1 and merged. No change has been done in the backport.
