### PR TITLE
[8.0][ADD][account_voucher_operating_unit]

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,38 @@
+language: python
+sudo: false
+cache: pip
+
+python:
+  - "2.7"
+
+addons:
+  apt:
+    packages:
+      - expect-dev  # provides unbuffer utility
+      - python-lxml  # because pip installation is slow
+
+env:
+  global:
+  - VERSION="8.0" LINT_CHECK="1"
+  - VERSION="8.0" ODOO_REPO="odoo/odoo" LINT_CHECK="0"
+  - VERSION="8.0" ODOO_REPO="OCA/OCB" LINT_CHECK="0"
+
+  matrix:
+  - LINT_CHECK="1"
+  - TRANSIFEX="0"
+  - TESTS="1" ODOO_REPO="odoo/odoo"
+  - TESTS="1" ODOO_REPO="OCA/OCB"
+
+virtualenv:
+  system_site_packages: true
+
+install:
+  - git clone --depth=1 https://github.com/OCA/maintainer-quality-tools.git ${HOME}/maintainer-quality-tools
+  - export PATH=${HOME}/maintainer-quality-tools/travis:${PATH}
+  - travis_install_nightly
+
+script:
+  - travis_run_tests
+
+after_success:
+  - travis_after_tests_success

--- a/account_voucher_operating_unit/README.rst
+++ b/account_voucher_operating_unit/README.rst
@@ -1,0 +1,60 @@
+.. image:: https://img.shields.io/badge/license-AGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl.html
+   :alt: License: AGPL-3
+
+==============================
+Account Voucher Operating Unit
+==============================
+
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/8.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/operating_unit/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+operating_unit/issues/new?body=module:%20
+account_voucher_operating_unit%0Aversion:%20
+8.0%0A%0A**Steps%20to%20reproduce**%0A-%20..
+.%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Ecosoft Co., Ltd. <info@ecosoft.co.th>
+* Eficent Business and IT Consulting Services S.L. <contact@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+* Xpansa Group <hello@xpansa.com>
+
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/account_voucher_operating_unit/README.rst
+++ b/account_voucher_operating_unit/README.rst
@@ -13,12 +13,12 @@ operate on the OU of the voucher.
 Customer or Supplier Payments
 -----------------------------
 
-* The Operating Unit that drives the Voucher is the one assigned to the
-default GL account of the Journal.
+* The Operating Unit that drives the Voucher is the one assigned to
+  the default GL account of the Journal.
 
 * The payment lines of the journal entries are assigned to this OU, and the
-Accounts Receivable or Accounts Payable lines that are created will belong
-to the OU of the AR / AP journal item that is being reconciled.
+  Accounts Receivable or Accounts Payable lines that are created will belong
+  to the OU of the AR / AP journal item that is being reconciled.
 
 * Operating Unit A can thus pay invoices posted by Operating Units B and C.
 
@@ -26,7 +26,7 @@ Customer or Supplier Receipts
 -----------------------------
 
 * The Operating Unit is assigned to the voucher, and then to the journal
-items when the voucher is posted.
+  items when the voucher is posted.
 
 
 Configuration

--- a/account_voucher_operating_unit/README.rst
+++ b/account_voucher_operating_unit/README.rst
@@ -6,6 +6,47 @@
 Account Voucher Operating Unit
 ==============================
 
+This module introduces Operating Units to the Account Voucher model. It also
+introduces security rules to manage access control only to users that can
+operate on the OU of the voucher.
+
+Customer or Supplier Payments
+-----------------------------
+
+* The Operating Unit that drives the Voucher is the one assigned to the
+default GL account of the Journal.
+
+* The payment lines of the journal entries are assigned to this OU, and the
+Accounts Receivable or Accounts Payable lines that are created will belong
+to the OU of the AR / AP journal item that is being reconciled.
+
+* Operating Unit A can thus pay invoices posted by Operating Units B and C.
+
+Customer or Supplier Receipts
+-----------------------------
+
+* The Operating Unit is assigned to the voucher, and then to the journal
+items when the voucher is posted.
+
+
+Configuration
+=============
+
+To configure this module, you need to:
+
+* For each bank/cash GL account that you intend to use in customer or supplier
+  payments you have to define the default Operating Unit that the payment
+  will be posted to. Go to *Invoicing / Configuration / Accounts / Accounts*
+  and search for your bank/cash accounts. Then add the default Operating Unit.
+
+
+Installation
+============
+
+You will need to install also the module 'Account Voucher Move Line Create
+Hooks' that is available in the `OCA/account-payment <https://github
+.com/OCA/operating_unit/issues>`_ repository.
+
 
 Usage
 =====
@@ -38,8 +79,8 @@ Images
 Contributors
 ------------
 
-* Ecosoft Co., Ltd. <info@ecosoft.co.th>
 * Eficent Business and IT Consulting Services S.L. <contact@eficent.com>
+* Ecosoft Co., Ltd. <info@ecosoft.co.th>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Xpansa Group <hello@xpansa.com>
 

--- a/account_voucher_operating_unit/__init__.py
+++ b/account_voucher_operating_unit/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# © 2015 Ecosoft Co. Ltd. - Kitti Upariphutthiphong
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import models

--- a/account_voucher_operating_unit/__openerp__.py
+++ b/account_voucher_operating_unit/__openerp__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# © 2015 Ecosoft Co. Ltd. - Kitti Upariphutthiphong
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+{
+    'name': 'Vouchers with Operating Units',
+    'version': '1.0',
+    'category': 'Generic Modules/Sales & Purchases',
+    "author": "Eficent Business and IT Consulting Services S.L., "
+              "Ecosoft Co. Ltd.,"
+              "Odoo Community Association (OCA)",
+    'website': 'http://www.eficent.com',
+    'depends': ['account_voucher_move_line_create_hooks',
+                'account_operating_unit', 'operating_unit'],
+    'data': [
+        'views/account_voucher_payment_receipt_view.xml',
+        'views/account_voucher_sales_purchase_view.xml',
+        'security/account_voucher_security.xml'
+    ],
+    'installable': True,
+}

--- a/account_voucher_operating_unit/__openerp__.py
+++ b/account_voucher_operating_unit/__openerp__.py
@@ -6,6 +6,7 @@
 
 {
     'name': 'Vouchers with Operating Units',
+    'summary': 'Introduces the operating unit to vouchers',
     'version': '1.0',
     'category': 'Generic Modules/Sales & Purchases',
     "author": "Eficent Business and IT Consulting Services S.L., "

--- a/account_voucher_operating_unit/__openerp__.py
+++ b/account_voucher_operating_unit/__openerp__.py
@@ -13,8 +13,7 @@
               "Ecosoft Co. Ltd.,"
               "Odoo Community Association (OCA)",
     'website': 'http://www.eficent.com',
-    'depends': ['account_voucher_move_line_create_hooks',
-                'account_operating_unit', 'operating_unit'],
+    'depends': ['account_operating_unit', 'operating_unit'],
     'data': [
         'views/account_voucher_payment_receipt_view.xml',
         'views/account_voucher_sales_purchase_view.xml',

--- a/account_voucher_operating_unit/models/__init__.py
+++ b/account_voucher_operating_unit/models/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# © 2015 Ecosoft Co. Ltd. - Kitti Upariphutthiphong
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import account_voucher

--- a/account_voucher_operating_unit/models/account_voucher.py
+++ b/account_voucher_operating_unit/models/account_voucher.py
@@ -22,7 +22,8 @@ class AccountVoucher(models.Model):
     def onchange_journal(self, cr, uid, ids, journal_id, line_ids, tax_id,
                          partner_id, date, amount, ttype, company_id,
                          context=None):
-        res = super(AccountVoucher, self).onchange_journal(cr, uid, ids,
+        res = super(AccountVoucher, self).onchange_journal(
+            cr, uid, ids,
             journal_id, line_ids, tax_id, partner_id, date, amount, ttype,
             company_id, context=context)
         if journal_id and ttype in ('payment', 'receipt'):
@@ -46,8 +47,6 @@ class AccountVoucher(models.Model):
         default=_get_default_operating_unit,
         required=False,
     )
-
-
 
     @api.one
     @api.constrains('operating_unit_id', 'company_id')

--- a/account_voucher_operating_unit/models/account_voucher.py
+++ b/account_voucher_operating_unit/models/account_voucher.py
@@ -14,22 +14,20 @@ class AccountVoucher(models.Model):
     @api.multi
     def _get_default_operating_unit(self):
         journal = self._get_journal()
+        if isinstance(journal, int):
+            journal = self.env['account.journal'].browse(journal)
         ttype = self.env.context.get('type', False)
         if ttype in ('payment', 'receipt'):
             return journal.default_debit_account_id.operating_unit_id.id
 
-    @api.v7
-    def onchange_journal(self, cr, uid, ids, journal_id, line_ids, tax_id,
-                         partner_id, date, amount, ttype, company_id,
-                         context=None):
+    @api.multi
+    def onchange_journal(self, journal_id, line_ids, tax_id,
+                         partner_id, date, amount, ttype, company_id):
         res = super(AccountVoucher, self).onchange_journal(
-            cr, uid, ids,
             journal_id, line_ids, tax_id, partner_id, date, amount, ttype,
-            company_id, context=context)
+            company_id)
         if journal_id and ttype in ('payment', 'receipt'):
-            journal = self.pool['account.journal'].browse(cr, uid,
-                                                          journal_id,
-                                                          context=context)
+            journal = self.env['account.journal'].browse(journal_id)
             res['value']['operating_unit_id'] = \
                 journal.default_debit_account_id.operating_unit_id.id
             res['value']['writeoff_operating_unit_id'] = \

--- a/account_voucher_operating_unit/models/account_voucher.py
+++ b/account_voucher_operating_unit/models/account_voucher.py
@@ -1,0 +1,160 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# © 2015 Ecosoft Co. Ltd. - Kitti Upariphutthiphong
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp import api, fields, models, _
+from openerp.exceptions import Warning
+
+
+class AccountVoucher(models.Model):
+    _inherit = "account.voucher"
+
+    operating_unit_id = fields.Many2one(
+        'operating.unit',
+        string='Operating Unit',
+        default=lambda self: self.env['res.users'].
+        operating_unit_default_get(self._uid),
+    )
+    writeoff_operating_unit_id = fields.Many2one(
+        'operating.unit',
+        string='Write-off Operating Unit',
+        default=lambda self: self.env['res.users'].
+        operating_unit_default_get(self._uid),
+        required=False,
+    )
+
+    @api.one
+    @api.constrains('operating_unit_id', 'company_id')
+    def _check_company_operating_unit(self):
+        if self.company_id and self.operating_unit_id and \
+                self.company_id != self.operating_unit_id.company_id:
+            raise Warning(_('The Company in the Move Line and in the '
+                            'Operating Unit must be the same.'))
+
+    @api.one
+    @api.constrains('operating_unit_id', 'journal_id', 'type')
+    def _check_journal_account_operating_unit(self):
+        if self.type not in ('payment', 'receipt'):
+            return True
+        if (
+            self.journal_id and self.operating_unit_id and
+            self.journal_id.default_debit_account_id and
+            self.journal_id.default_debit_account_id.operating_unit_id and
+            self.journal_id.default_debit_account_id.operating_unit_id.id !=
+                self.operating_unit_id.id
+        ) or (
+            self.journal_id and self.operating_unit_id and
+            self.journal_id.default_credit_account_id and
+            self.journal_id.default_credit_account_id.operating_unit_id and
+            self.journal_id.default_credit_account_id.operating_unit_id.id !=
+                self.operating_unit_id.id
+        ):
+            raise Warning(_('The Default Debit and Credit Accounts '
+                            'defined in the Journal must have the same '
+                            'Operating Unit as the one indicated in the '
+                            'payment or receipt.'))
+        return True
+
+    @api.model
+    def first_move_line_get(self, voucher_id, move_id,
+                            company_currency, current_currency):
+        res = super(AccountVoucher, self).first_move_line_get(
+            voucher_id, move_id, company_currency, current_currency)
+        voucher = self.env['account.voucher'].browse(voucher_id)
+        if not voucher.operating_unit_id:
+            return res
+        if voucher.type in ('payment', 'receipt'):
+            if voucher.account_id.operating_unit_id:
+                res['operating_unit_id'] = \
+                    voucher.account_id.operating_unit_id.id
+            else:
+                raise Warning(_('Account %s - %s does not have a '
+                                'default operating unit. \n '
+                                'Payment Method %s default Debit and '
+                                'Credit accounts should have a '
+                                'default Operating Unit.') %
+                              (voucher.account_id.code,
+                               voucher.account_id.name,
+                               voucher.journal_id.name))
+        else:
+            if voucher.operating_unit_id:
+                res['operating_unit_id'] = voucher.operating_unit_id.id
+            else:
+                raise Warning(_('The Voucher must have an Operating '
+                                'Unit.'))
+        return res
+
+    @api.model
+    def _voucher_move_line_prepare(self, voucher_id, line_total,
+                                   move_id, company_currency, current_currency,
+                                   voucher_line_id, ):
+        res = super(AccountVoucher, self)._voucher_move_line_prepare(
+            voucher_id, line_total, move_id, company_currency,
+            current_currency, voucher_line_id)
+        line = self.env['account.voucher.line'].browse(voucher_line_id)
+
+        if line.voucher_id.type in ('sale', 'purchase') \
+                and line.voucher_id.operating_unit_id:
+            res['operating_unit_id'] = line.voucher_id.operating_unit_id.id
+        elif line.move_line_id and line.move_line_id.operating_unit_id:
+            res['operating_unit_id'] = line.move_line_id.operating_unit_id.id
+        return res
+
+    @api.model
+    def _voucher_move_line_foreign_currency_prepare(
+            self, voucher_id, line_total, move_id,
+            company_currency, current_currency, voucher_line_id,
+            foreign_currency_diff):
+
+        res = super(AccountVoucher, self)._voucher_move_line_prepare(
+            voucher_id, line_total, move_id, company_currency,
+            current_currency, voucher_line_id, foreign_currency_diff)
+        line = self.env['account.voucher.line'].browse(voucher_line_id)
+        if line.move_line_id and line.move_line_id.operating_unit_id:
+            res['operating_unit_id'] = line.move_line_id.operating_unit_id.id
+        return res
+
+    @api.model
+    def writeoff_move_line_get(self, voucher_id,
+                               line_total, move_id, name,
+                               company_currency, current_currency):
+        res = super(AccountVoucher, self).writeoff_move_line_get(
+            voucher_id, line_total, move_id, name, company_currency,
+            current_currency)
+        if res:
+            voucher = self.env['account.voucher'].browse(voucher_id)
+            if (voucher.payment_option == 'with_writeoff' or
+                    voucher.partner_id):
+                if not voucher.writeoff_operating_unit_id:
+                    raise Warning(_('Please indicate a write-off Operating '
+                                    'Unit.'))
+                else:
+                    res['operating_unit_id'] = \
+                        voucher.writeoff_operating_unit_id.id
+            else:
+                if not voucher.writeoff_operating_unit_id:
+                    if not voucher.account_id.operating_unit_id:
+                        raise Warning(_('Please indicate a write-off '
+                                        'Operating Unit or a default '
+                                        'Operating Unit for account %s') %
+                                      voucher.account_id.code)
+                    else:
+                        res['operating_unit_id'] = \
+                            voucher.account_id.operating_unit_id.id
+                else:
+                        res['operating_unit_id'] = \
+                            voucher.writeoff_operating_unit_id.id
+        return res
+
+
+class AccountVoucherLine(models.Model):
+    _inherit = "account.voucher.line"
+
+    operating_unit_id = fields.Many2one(
+        'operating.unit',
+        related='voucher_id.operating_unit_id',
+        string='Operating Unit', readonly=True,
+        store=True,
+    )

--- a/account_voucher_operating_unit/security/account_voucher_security.xml
+++ b/account_voucher_operating_unit/security/account_voucher_security.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+<data noupdate="0">
+
+    <record id="ir_rule_voucher_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id" ref="account_voucher.model_account_voucher"/>
+        <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">Vouchers from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+
+    <record id="ir_rule_voucher_line_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id"
+               ref="account_voucher.model_account_voucher_line"/>
+        <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">Voucher lines from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+
+</data>
+</openerp>

--- a/account_voucher_operating_unit/tests/__init__.py
+++ b/account_voucher_operating_unit/tests/__init__.py
@@ -1,0 +1,8 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# © 2015 Ecosoft Co. Ltd. - Kitti Upariphutthiphong
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from . import test_account_voucher_operating_unit
+from . import test_payment_operating_unit

--- a/account_voucher_operating_unit/tests/test_account_voucher_operating_unit.py
+++ b/account_voucher_operating_unit/tests/test_account_voucher_operating_unit.py
@@ -1,0 +1,131 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# © 2015 Ecosoft Co. Ltd. - Kitti Upariphutthiphong
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp.tests import common
+from datetime import date
+
+
+class TestAccountVoucherOperatingUnit(common.TransactionCase):
+
+    # Setup 2 invoices,  1st invoice is created for Main OU
+    #                    2nd invoice is created for B2C
+    # Validate invoices
+    # In Customer Payment,
+    #    user_all that have access to both OU, will get 2 line.
+    #    user_b2c that have access to B2C will get 1 line.
+    # Use user_1 to make payment
+    # Check journal enteries
+
+    def setUp(self):
+        super(TestAccountVoucherOperatingUnit, self).setUp()
+        self.ResUsers = self.env['res.users']
+        self.Invoice = self.env['account.invoice']
+        self.InvoiceLine = self.env['account.invoice.line']
+        self.Account = self.env['account.account']
+        self.AccountType = self.env['account.account.type']
+        self.Voucher = self.env['account.voucher']
+        # company
+        self.company1 = self.env.ref('base.main_company')
+        # groups
+        self.group_account_user = self.env.ref('account.group_account_user')
+        # Main Operating Unit
+        self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        # B2C Operating Unit
+        self.b2c = self.env.ref('operating_unit.b2c_operating_unit')
+        # Partner
+        self.partner1 = self.env.ref('base.res_partner_1')
+        # Products
+        self.product1 = self.env.ref('product.product_product_7')
+        self.product2 = self.env.ref('product.product_product_9')
+        self.product3 = self.env.ref('product.product_product_11')
+        # Payment journal
+        self.payment_journal = self.env.ref('account.bank_journal')
+        self.payment_account = self.env.ref('account.bnk')
+        # Create users
+        self.user_all_id = self._create_user('user_all',
+                                             [self.group_account_user],
+                                             self.company1,
+                                             [self.ou1, self.b2c])
+        self.user_b2c_id = self._create_user('user_b2c',
+                                             [self.group_account_user],
+                                             self.company1,
+                                             [self.b2c])
+        # Create Invoice with Main Operating Unit
+        self.invoice_ou = self._create_invoice(self.ou1.id)
+        # Create Invoice with B2C
+        self.invoice_b2c = self._create_invoice(self.b2c.id)
+
+        # user_b2c to create Customer Payment
+        self.payment = self._create_customer_payment(
+            self.user_all_id, self.ou1.id, self.partner1.id)
+
+    def _create_user(self, login, groups, company, operating_units):
+        """ Create a user."""
+        group_ids = [group.id for group in groups]
+        user =\
+            self.ResUsers.with_context({'no_reset_password': True}).\
+            create({
+                'name': 'Budget User',
+                'login': login,
+                'password': 'demo',
+                'email': 'chicago@yourcompany.com',
+                'company_id': company.id,
+                'company_ids': [(4, company.id)],
+                'operating_unit_ids': [(4, ou.id) for ou in operating_units],
+                'groups_id': [(6, 0, group_ids)]
+            })
+        return user.id
+
+    def _create_invoice(self, operating_unit_id):
+        """Create & Validate the invoice."""
+        line_products = [(self.product1, 2)]
+        # Prepare invoice lines
+        lines = []
+        user_types = self.AccountType.search([('code', '=', 'expense')])
+        user_type_id = user_types and user_types[0].id or False
+        for product, qty in line_products:
+            line_values = {
+                'name': product.name,
+                'product_id': product.id,
+                'quantity': qty,
+                'price_unit': 100,
+                'account_id': self.Account.search(
+                    [('user_type', '=', user_type_id)], limit=1).id,
+            }
+            lines.append((0, 0, line_values))
+        inv_vals = {
+            'partner_id': self.partner1.id,
+            'account_id': self.partner1.property_account_payable.id,
+            'operating_unit_id': operating_unit_id,
+            'name': "Customer Invoice (Main OU)",
+            'reference_type': "none",
+            'type': 'out_invoice',
+            'invoice_line': lines,
+        }
+        # Create invoice
+        self.invoice =\
+            self.Invoice.sudo(self.user_all_id).create(inv_vals)
+        # Validate the invoice
+        self.invoice.sudo(self.user_all_id).signal_workflow('invoice_open')
+        return self.invoice
+
+    def _create_customer_payment(self, user_id, operating_unit_id, partner_id):
+        """Create & Validate the invoice."""
+        pay_vals = {
+            'type': 'payment',
+            'account_id': self.payment_account.id,
+            'amount': 0.0,
+            'company_id': self.company1.id,
+            'journal_id': self.payment_journal.id,
+            'name': 'Customer Payment: B2C',
+            'partner_id': self.partner1.id,
+            'date': date.today(),
+            'operating_unit_id': operating_unit_id,
+        }
+        # Create invoice
+        self.payment =\
+            self.Voucher.sudo(user_id).create(pay_vals)
+        return self.payment

--- a/account_voucher_operating_unit/tests/test_payment_operating_unit.py
+++ b/account_voucher_operating_unit/tests/test_payment_operating_unit.py
@@ -34,5 +34,3 @@ class TestPaymentOU(test_ou.TestAccountVoucherOperatingUnit):
             amount, rate, partner_id, journal_id, currency_id, ttype, date,
             payment_rate_currency_id, company_id)
         self.assertEqual(len(res['value']['line_cr_ids']), 1)
-        #print res
-        # save payment, and validate

--- a/account_voucher_operating_unit/tests/test_payment_operating_unit.py
+++ b/account_voucher_operating_unit/tests/test_payment_operating_unit.py
@@ -1,0 +1,38 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L.
+# - Jordi Ballester Alomar
+# © 2015 Ecosoft Co. Ltd. - Kitti Upariphutthiphong
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+
+from openerp.addons.account_voucher_operating_unit.tests import\
+    test_account_voucher_operating_unit as test_ou
+
+
+class TestPaymentOU(test_ou.TestAccountVoucherOperatingUnit):
+
+    def test_create_customer_payment(self):
+        """ Test Create Payment of Voucher Operating Unit """
+        # user_b2c, on customer payment, show only invoices on B2C
+        amount = 300
+        rate = self.payment.payment_rate
+        partner_id = self.payment.partner_id.id
+        journal_id = self.payment.journal_id.id
+        currency_id = self.payment.currency_id.id
+        ttype = self.payment.type
+        date = self.payment.date
+        payment_rate_currency_id = self.payment.payment_rate_currency_id.id
+        company_id = self.payment.company_id.id
+
+        # user_all will see both Main OU and B2C invoices (2 records)
+        res = self.payment.sudo(self.user_all_id).onchange_amount(
+            amount, rate, partner_id, journal_id, currency_id, ttype, date,
+            payment_rate_currency_id, company_id)
+        self.assertEqual(len(res['value']['line_cr_ids']), 2)
+
+        # user_b2c will see only B2C invoices (1 records)
+        res = self.payment.sudo(self.user_b2c_id).onchange_amount(
+            amount, rate, partner_id, journal_id, currency_id, ttype, date,
+            payment_rate_currency_id, company_id)
+        self.assertEqual(len(res['value']['line_cr_ids']), 1)
+        #print res
+        # save payment, and validate

--- a/account_voucher_operating_unit/views/account_voucher_payment_receipt_view.xml
+++ b/account_voucher_operating_unit/views/account_voucher_payment_receipt_view.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <!-- Supplier Payment -->
+        <record model="ir.ui.view" id="view_vendor_payment_form">
+            <field name="name">account.voucher.payment.form</field>
+            <field name="model">account.voucher</field>
+            <field name="inherit_id"
+                   ref="account_voucher.view_vendor_payment_form"/>
+            <field name="arch" type="xml">
+                <field name="journal_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+                <field name="writeoff_acc_id" position="after">
+                    <field name="writeoff_operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <!-- Register Payment Form (old Pay Invoice wizard) -->
+        <record model="ir.ui.view" id="view_vendor_receipt_dialog_form">
+            <field name="name">account.voucher.receipt.dialog.form</field>
+            <field name="model">account.voucher</field>
+            <field name="inherit_id"
+                   ref="account_voucher.view_vendor_receipt_dialog_form"/>
+            <field name="arch" type="xml">
+                <field name="journal_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+                <field name="writeoff_acc_id" position="after">
+                    <field name="writeoff_operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <!-- Customer Payment -->
+        <record model="ir.ui.view" id="view_vendor_receipt_form">
+            <field name="name">account.voucher.receipt.form</field>
+            <field name="model">account.voucher</field>
+            <field name="inherit_id"
+                   ref="account_voucher.view_vendor_receipt_form"/>
+            <field name="arch" type="xml">
+                <field name="journal_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+                <field name="writeoff_acc_id" position="after">
+                    <field name="writeoff_operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/account_voucher_operating_unit/views/account_voucher_sales_purchase_view.xml
+++ b/account_voucher_operating_unit/views/account_voucher_sales_purchase_view.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openerp>
+    <data>
+
+        <record id="view_voucher_filter_vendor" model="ir.ui.view">
+            <field name="name">account.voucher.purchase.select</field>
+            <field name="model">account.voucher</field>
+            <field name="inherit_id"
+                   ref="account_voucher.view_voucher_filter_vendor"/>
+            <field name="arch" type="xml">
+                <field name="period_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_voucher_filter_sale" model="ir.ui.view">
+            <field name="name">account.voucher.sale.select</field>
+            <field name="model">account.voucher</field>
+            <field name="inherit_id"
+                   ref="account_voucher.view_voucher_filter_sale"/>
+            <field name="arch" type="xml">
+                <field name="period_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="view_sale_receipt_form">
+            <field name="name">account.voucher.sale.form</field>
+            <field name="model">account.voucher</field>
+            <field name="inherit_id"
+                   ref="account_voucher.view_sale_receipt_form"/>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="after">
+                    <field name="operating_unit_id" required="1" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record model="ir.ui.view" id="view_purchase_receipt_form">
+            <field name="name">account.voucher.purchase.form</field>
+            <field name="model">account.voucher</field>
+            <field name="inherit_id"
+                   ref="account_voucher.view_purchase_receipt_form"/>
+            <field name="arch" type="xml">
+                <field name="currency_id" position="after">
+                    <field name="operating_unit_id" required="1" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
# 
# Account Voucher Operating Unit

This module introduces Operating Units to the Account Voucher model. It also
introduces security rules to manage access control only to users that can
operate on the OU of the voucher.
## Customer or Supplier Payments
- The Operating Unit that drives the Voucher is the one assigned to the
  default GL account of the Journal.
- The payment lines of the journal entries are assigned to this OU, and the
  Accounts Receivable or Accounts Payable lines that are created will belong
  to the OU of the AR / AP journal item that is being reconciled.
- Operating Unit A can thus pay invoices posted by Operating Units B and C.
## Customer or Supplier Receipts
- The Operating Unit is assigned to the voucher, and then to the journal
  items when the voucher is posted.
# Configuration

To configure this module, you need to:
- For each bank/cash GL account that you intend to use in customer or supplier
  payments you have to define the default Operating Unit that the payment
  will be posted to. Go to _Invoicing / Configuration / Accounts / Accounts_
  and search for your bank/cash accounts. Then add the default Operating Unit.
