### PR TITLE
[8.0][ADD] [sale operating unit]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![Runbot Status](https://runbot.odoo-community.org/runbot/badge/flat/213/8.0.svg)](https://runbot.odoo-community.org/runbot/repo/github-com-oca-operating-unit-213)
-[![Build Status](https://travis-ci.org/OCA/operating-unit.svg?branch=8.0)](https://travis-ci.org/OCA/operating-unit)
-[![Coverage Status](https://coveralls.io/repos/OCA/operating-unit/badge.svg?branch=8.0&service=github)](https://coveralls.io/github/OCA/operating-unit?branch=8.0)
+[![Runbot Status](https://runbot.odoo-community.org/runbot/badge/flat/213/9.0.svg)](https://runbot.odoo-community.org/runbot/repo/github-com-oca-operating-unit-213)
+[![Build Status](https://travis-ci.org/OCA/operating-unit.svg?branch=9.0)](https://travis-ci.org/OCA/operating-unit)
+[![Coverage Status](https://coveralls.io/repos/OCA/operating-unit/badge.svg?branch=9.0&service=github)](https://coveralls.io/github/OCA/operating-unit?branch=9.0)
 [![Code Climate](https://codeclimate.com/github/OCA/operating-unit/badges/gpa.svg)](https://codeclimate.com/github/OCA/operating-unit)
 
 # Operating Units
@@ -19,7 +19,7 @@ This part will be replaced when running the oca-gen-addons-table script from OCA
 
 Translation Status
 ------------------
-[![Transifex Status](https://www.transifex.com/projects/p/OCA-operating-unit-8-0/chart/image_png)](https://www.transifex.com/projects/p/OCA-operating-unit-8-0)
+[![Transifex Status](https://www.transifex.com/projects/p/OCA-operating-unit-9-0/chart/image_png)](https://www.transifex.com/projects/p/OCA-operating-unit-9-0)
 
 ----
 

--- a/sale_operating_unit/README.rst
+++ b/sale_operating_unit/README.rst
@@ -1,0 +1,71 @@
+.. image:: https://img.shields.io/badge/license-AGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/agpl.html
+   :alt: License: AGPL-3
+
+===============================
+Operating Unit in Sales
+===============================
+
+This module was written to extend the Sales capabilities of Odoo.
+This module introduces the operating unit to the Sales Order.
+Security rules are defined to ensure that users can only display the
+Sales Orders in which they are allowed access to.
+
+Installation
+============
+
+No additional installation instructions are required.
+
+Configuration
+=============
+
+Go to 'Settings / Technical / Actions / User-defined Defaults' and remove
+the default set for the Shop.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/7.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/sale_operating_unit/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed `feedback
+<https://github.com/OCA/
+sale_operating_unit/issues/new?body=module:%20
+sale_operating_unit%0Aversion:%20
+7.0%0A%0A**Steps%20to%20reproduce**%0A-%20...%0A%0A**Current%20behavior**%0A%0A**Expected%20behavior**>`_.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Eficent Business and IT Consulting Services S.L. <contact@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.

--- a/sale_operating_unit/__init__.py
+++ b/sale_operating_unit/__init__.py
@@ -4,4 +4,3 @@
 # © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from . import models
-from . import tests

--- a/sale_operating_unit/__init__.py
+++ b/sale_operating_unit/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import models
+from . import tests

--- a/sale_operating_unit/__openerp__.py
+++ b/sale_operating_unit/__openerp__.py
@@ -14,7 +14,7 @@
     "license": "AGPL-3",
     "website": "http://www.eficent.com",
     "category": "Sales Management",
-    "depends": ["sale", "operating_unit", "stock_operating_unit"],
+    "depends": ["sale", "operating_unit", "sale_stock"],
     "data": [
         "views/sale_view.xml",
         "security/sale_security.xml",

--- a/sale_operating_unit/__openerp__.py
+++ b/sale_operating_unit/__openerp__.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+{
+    "name": "Operating Unit in Sales",
+    "version": "8.0.1.0.0",
+    "summary": "An operating unit (OU) is an organizational entity part of a\
+        company",
+    "author": "Eficent Business and IT Consulting Services S.L., "
+              "Serpent Consulting Services Pvt. Ltd.,"
+              "Odoo Community Association (OCA)",
+    "license": "AGPL-3",
+    "website": "http://www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["sale", "operating_unit"],
+    "data": [
+        "views/sale_view.xml",
+        "security/sale_security.xml",
+    ],
+    'installable': True,
+    'active': False,
+}

--- a/sale_operating_unit/__openerp__.py
+++ b/sale_operating_unit/__openerp__.py
@@ -14,7 +14,7 @@
     "license": "AGPL-3",
     "website": "http://www.eficent.com",
     "category": "Sales Management",
-    "depends": ["sale", "operating_unit"],
+    "depends": ["sale", "operating_unit", "stock_operating_unit"],
     "data": [
         "views/sale_view.xml",
         "security/sale_security.xml",

--- a/sale_operating_unit/__openerp__.py
+++ b/sale_operating_unit/__openerp__.py
@@ -6,14 +6,14 @@
 {
     "name": "Operating Unit in Sales",
     "version": "8.0.1.0.0",
-    "summary": "An operating unit (OU) is an organizational entity part of a\
-        company",
+    "summary": "An operating unit (OU) is an organizational entity part of a "
+        "company",
     "author": "Eficent Business and IT Consulting Services S.L., "
               "Serpent Consulting Services Pvt. Ltd.,"
               "Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "http://www.eficent.com",
-    "category": "Purchase Management",
+    "category": "Sales Management",
     "depends": ["sale", "operating_unit"],
     "data": [
         "views/sale_view.xml",

--- a/sale_operating_unit/__openerp__.py
+++ b/sale_operating_unit/__openerp__.py
@@ -7,7 +7,7 @@
     "name": "Operating Unit in Sales",
     "version": "8.0.1.0.0",
     "summary": "An operating unit (OU) is an organizational entity part of a "
-        "company",
+               "company",
     "author": "Eficent Business and IT Consulting Services S.L., "
               "Serpent Consulting Services Pvt. Ltd.,"
               "Odoo Community Association (OCA)",

--- a/sale_operating_unit/__openerp__.py
+++ b/sale_operating_unit/__openerp__.py
@@ -14,7 +14,7 @@
     "license": "AGPL-3",
     "website": "http://www.eficent.com",
     "category": "Sales Management",
-    "depends": ["sale", "operating_unit", "sale_stock"],
+    "depends": ["sale", "operating_unit", "account_operating_unit"],
     "data": [
         "views/sale_view.xml",
         "security/sale_security.xml",

--- a/sale_operating_unit/models/__init__.py
+++ b/sale_operating_unit/models/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import sale

--- a/sale_operating_unit/models/sale.py
+++ b/sale_operating_unit/models/sale.py
@@ -24,14 +24,6 @@ class SaleOrder(models.Model):
             raise Warning(_('Configuration error!\nThe Company in the\
             Sales Order and in the Operating Unit must be the same.'))
 
-    @api.one
-    @api.constrains('operating_unit_id', 'warehouse_id')
-    def _check_wh_operating_unit(self):
-        if self.operating_unit_id and\
-                self.operating_unit_id != self.warehouse_id.operating_unit_id:
-            raise Warning(_('Configuration error!\nThe Operating Unit \
-            in the Sales Order and in the Warehouse must be the same.'))
-
     @api.model
     def _make_invoice(self, order, lines):
         inv_id = super(SaleOrder, self)._make_invoice(order, lines)

--- a/sale_operating_unit/models/sale.py
+++ b/sale_operating_unit/models/sale.py
@@ -1,0 +1,42 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openerp import api, fields, models
+from openerp.tools.translate import _
+from openerp.exceptions import Warning
+
+
+class SaleOrder(models.Model):
+
+    _inherit = 'sale.order'
+
+    operating_unit_id = fields.Many2one('operating.unit', 'Operating Unit',
+                                        default=lambda self:
+                                        self.env['res.users'].
+                                        operating_unit_default_get(self._uid))
+
+    @api.one
+    @api.constrains('operating_unit_id', 'company_id')
+    def _check_company_operating_unit(self):
+        if self.company_id and self.operating_unit_id and\
+                self.company_id != self.operating_unit_id.company_id:
+            raise Warning(_('Configuration error!\nThe Company in the\
+            Sales Order and in the Operating Unit must be the same.'))
+
+    @api.model
+    def _make_invoice(self, order, lines):
+        res = super(SaleOrder, self)._make_invoice(order, lines)
+        invoice = self.env['account.invoice'].browse(res)
+        invoice.write({'operating_unit_id': order.operating_unit_id.id})
+        return res
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    operating_unit_id = fields.Many2one('operating.unit',
+                                        related='order_id.operating_unit_id',
+                                        string='Operating Unit',
+                                        readonly=True)

--- a/sale_operating_unit/models/sale.py
+++ b/sale_operating_unit/models/sale.py
@@ -4,12 +4,11 @@
 # © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
 from openerp import api, fields, models
-from openerp.tools.translate import _
 from openerp.exceptions import Warning
+from openerp.tools.translate import _
 
 
 class SaleOrder(models.Model):
-
     _inherit = 'sale.order'
 
     operating_unit_id = fields.Many2one('operating.unit', 'Operating Unit',
@@ -25,12 +24,20 @@ class SaleOrder(models.Model):
             raise Warning(_('Configuration error!\nThe Company in the\
             Sales Order and in the Operating Unit must be the same.'))
 
+    @api.one
+    @api.constrains('operating_unit_id', 'warehouse_id')
+    def _check_wh_operating_unit(self):
+        if self.operating_unit_id and\
+                self.operating_unit_id != self.warehouse_id.operating_unit_id:
+            raise Warning(_('Configuration error!\nThe Operating Unit \
+            in the Sales Order and in the Warehouse must be the same.'))
+
     @api.model
     def _make_invoice(self, order, lines):
-        res = super(SaleOrder, self)._make_invoice(order, lines)
-        invoice = self.env['account.invoice'].browse(res)
+        inv_id = super(SaleOrder, self)._make_invoice(order, lines)
+        invoice = self.env['account.invoice'].browse(inv_id)
         invoice.write({'operating_unit_id': order.operating_unit_id.id})
-        return res
+        return inv_id
 
 
 class SaleOrderLine(models.Model):

--- a/sale_operating_unit/security/sale_security.xml
+++ b/sale_operating_unit/security/sale_security.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <record id="ir_rule_sale_order_allowed_operating_units"
+                model="ir.rule">
+            <field name="model_id" ref="sale.model_sale_order"/>
+            <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+            <field name="name">Sales Orders from allowed operating units</field>
+            <field name="global" eval="True"/>
+            <field eval="0" name="perm_unlink"/>
+            <field eval="0" name="perm_write"/>
+            <field eval="1" name="perm_read"/>
+            <field eval="0" name="perm_create"/>
+        </record>
+
+        <record id="ir_rule_sale_order_line_allowed_operating_units"
+                model="ir.rule">
+            <field name="model_id" ref="sale.model_sale_order_line"/>
+            <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+            <field name="name">Sales Order lines from allowed operating units</field>
+            <field name="global" eval="True"/>
+            <field eval="0" name="perm_unlink"/>
+            <field eval="0" name="perm_write"/>
+            <field eval="1" name="perm_read"/>
+            <field eval="0" name="perm_create"/>
+        </record>
+
+    </data>
+</openerp>

--- a/sale_operating_unit/tests/__init__.py
+++ b/sale_operating_unit/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from . import test_sale_operating_unit

--- a/sale_operating_unit/tests/test_sale_operating_unit.py
+++ b/sale_operating_unit/tests/test_sale_operating_unit.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl.html).
+from openerp import netsvc
+from openerp.tests import common
+
+
+class TestSaleOperatingUnit(common.TransactionCase):
+
+    def setUp(self):
+        super(TestSaleOperatingUnit, self).setUp()
+        self.res_groups = self.env['res.groups']
+        self.partner_model = self.env['res.partner']
+        self.res_users_model = self.env['res.users']
+        self.sale_model = self.env['sale.order']
+        self.sale_order_model = self.env['sale.order.line']
+        self.acc_move_model = self.env['account.move']
+        self.acc_invoice_model = self.env['account.invoice']
+        self.res_company_model = self.env['res.company']
+        self.product_model = self.env['product.product']
+        self.operating_unit_model = self.env['operating.unit']
+        self.company_model = self.env['res.company']
+        self.payment_model = self.env['sale.advance.payment.inv']
+        # Company
+        self.company = self.env.ref('base.main_company')
+        self.grp_sale_user = self.env.ref('base.group_sale_manager')
+        self.grp_acc_user = self.env.ref('account.group_account_invoice')
+        # Main Operating Unit
+        self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        # B2B Operating Unit
+        self.b2b = self.env.ref('operating_unit.b2b_operating_unit')
+        # B2C Operating Unit
+        self.b2c = self.env.ref('operating_unit.b2c_operating_unit')
+        # Payment Term
+        self.pay = self.env.ref('account.account_payment_term_immediate')
+        # Customer
+        self.customer = self.env.ref('base.res_partner_2')
+        # Price list
+        self.pricelist = self.env.ref('product.list0')
+        # Partner
+        self.partner1 = self.env.ref('base.res_partner_1')
+        # Products
+        self.product1 = self.env.ref('product.product_product_7')
+        # Create user1
+        self.user1 = self._create_user('user_1', [self.grp_sale_user,
+                                                  self.grp_acc_user],
+                                       self.company, [self.ou1, self.b2c])
+        # Create user2
+        self.user2 = self._create_user('user_2', [self.grp_sale_user,
+                                                  self.grp_acc_user],
+                                       self.company, [self.b2c])
+        # Create Sale Order1
+        self.sale1 = self._create_sale_order(self.user1.id, self.customer,
+                                             self.product1, self.pricelist,
+                                             self.ou1)
+        # Create Sale Order2
+        self.sale2 = self._create_sale_order(self.user2.id, self.customer,
+                                             self.product1, self.pricelist,
+                                             self.b2c)
+
+    def _create_user(self, login, groups, company, operating_units,
+                     context=None):
+        """Create a user."""
+        group_ids = [group.id for group in groups]
+        user = self.res_users_model.create({
+            'name': 'Test Sales User',
+            'login': login,
+            'password': 'demo',
+            'email': 'example@yourcompany.com',
+            'company_id': company.id,
+            'company_ids': [(4, company.id)],
+            'operating_unit_ids': [(4, ou.id) for ou in operating_units],
+            'groups_id': [(6, 0, group_ids)]
+        })
+        return user
+
+    def _create_sale_order(self, uid, customer, product, pricelist,
+                           operating_unit):
+        """Create a sale order."""
+        sale = self.sale_model.sudo(uid).create({
+            'partner_id': customer.id,
+            'partner_invoice_id': customer.id,
+            'partner_shipping_id': customer.id,
+            'pricelist_id': pricelist.id,
+            'operating_unit_id': operating_unit.id
+        })
+        self.sale_order_model.sudo(uid).create({
+            'order_id': sale.id,
+            'product_id': product.id,
+            'name': 'Sale Order Line'
+        })
+        return sale
+
+    def _confirm_sale(self, sale):
+        sale.action_button_confirm()
+        payment = self.payment_model.create({
+            'advance_payment_method': 'all'
+        })
+        sale_context = {
+            'active_id': sale.id,
+            'active_ids': sale.ids,
+            'active_model': 'sale.order',
+            'open_invoices': True,
+        }
+        res = payment.with_context(sale_context).create_invoices()
+        invoice_id = res['res_id']
+        return invoice_id
+
+    def test_security(self):
+        """Test Sale Operating Unit"""
+        # User 2 is only assigned to Operating Unit B2C, and cannot
+        # Access Sales order from Main Operating Unit.
+        sale = self.sale_model.sudo(self.user2.id).search(
+                                          [('id', '=', self.sale1.id),
+                                           ('operating_unit_id', '=',
+                                           self.ou1.id)])
+        self.assertEqual(sale.ids, [], 'User 2 should not have access to '
+                                       'OU %s' % self.ou1.name)
+        # Confirm Sale1
+        self._confirm_sale(self.sale1)
+        # Confirm Sale2
+        b2c_invoice_id = self._confirm_sale(self.sale2)
+        # Checks that invoice has OU b2c
+        b2c = self.acc_invoice_model.sudo(self.user2.id).search(
+                                         [('id', '=', b2c_invoice_id),
+                                          ('operating_unit_id', '=',
+                                           self.b2c.id)])
+        self.assertNotEqual(b2c.ids, [], 'Invoice should have b2c OU')

--- a/sale_operating_unit/tests/test_sale_operating_unit.py
+++ b/sale_operating_unit/tests/test_sale_operating_unit.py
@@ -29,10 +29,6 @@ class TestSaleOperatingUnit(common.TransactionCase):
         self.grp_acc_user = self.env.ref('account.group_account_invoice')
         # Main Operating Unit
         self.ou1 = self.env.ref('operating_unit.main_operating_unit')
-        # Main warehouse
-        self.wh1 = self.env.ref('stock.warehouse0')
-        # b2c warehouse
-        self.wh2 = self.env.ref('stock_operating_unit.stock_warehouse_b2c')
         # B2B Operating Unit
         self.b2b = self.env.ref('operating_unit.b2b_operating_unit')
         # B2C Operating Unit
@@ -58,11 +54,11 @@ class TestSaleOperatingUnit(common.TransactionCase):
         # Create Sale Order1
         self.sale1 = self._create_sale_order(self.user1.id, self.customer,
                                              self.product1, self.pricelist,
-                                             self.wh1, self.ou1)
+                                             self.ou1)
         # Create Sale Order2
         self.sale2 = self._create_sale_order(self.user2.id, self.customer,
                                              self.product1, self.pricelist,
-                                             self.wh2, self.b2c)
+                                             self.b2c)
 
     def _create_user(self, login, groups, company, operating_units,
                      context=None):
@@ -80,18 +76,17 @@ class TestSaleOperatingUnit(common.TransactionCase):
         })
         return user
 
-    def _create_sale_order(self, uid, customer, product, pricelist, warehouse,
+    def _create_sale_order(self, uid, customer, product, pricelist,
                            operating_unit):
         """Create a sale order."""
-        sale = self.sale_model.create({
+        sale = self.sale_model.sudo(uid).create({
             'partner_id': customer.id,
             'partner_invoice_id': customer.id,
             'partner_shipping_id': customer.id,
             'pricelist_id': pricelist.id,
-            'operating_unit_id': operating_unit.id,
-            'warehouse_id': warehouse.id
+            'operating_unit_id': operating_unit.id
         })
-        self.sale_order_model.create({
+        self.sale_order_model.sudo(uid).create({
             'order_id': sale.id,
             'product_id': product.id,
             'name': 'Sale Order Line'

--- a/sale_operating_unit/tests/test_sale_operating_unit.py
+++ b/sale_operating_unit/tests/test_sale_operating_unit.py
@@ -29,6 +29,10 @@ class TestSaleOperatingUnit(common.TransactionCase):
         self.grp_acc_user = self.env.ref('account.group_account_invoice')
         # Main Operating Unit
         self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        # Main warehouse
+        self.wh1 = self.env.ref('stock.warehouse0')
+        # b2c warehouse
+        self.wh2 = self.env.ref('stock_operating_unit.stock_warehouse_b2c')
         # B2B Operating Unit
         self.b2b = self.env.ref('operating_unit.b2b_operating_unit')
         # B2C Operating Unit
@@ -54,11 +58,11 @@ class TestSaleOperatingUnit(common.TransactionCase):
         # Create Sale Order1
         self.sale1 = self._create_sale_order(self.user1.id, self.customer,
                                              self.product1, self.pricelist,
-                                             self.ou1)
+                                             self.wh1, self.ou1)
         # Create Sale Order2
         self.sale2 = self._create_sale_order(self.user2.id, self.customer,
                                              self.product1, self.pricelist,
-                                             self.b2c)
+                                             self.wh2, self.b2c)
 
     def _create_user(self, login, groups, company, operating_units,
                      context=None):
@@ -76,17 +80,18 @@ class TestSaleOperatingUnit(common.TransactionCase):
         })
         return user
 
-    def _create_sale_order(self, uid, customer, product, pricelist,
+    def _create_sale_order(self, uid, customer, product, pricelist, warehouse,
                            operating_unit):
         """Create a sale order."""
-        sale = self.sale_model.sudo(uid).create({
+        sale = self.sale_model.create({
             'partner_id': customer.id,
             'partner_invoice_id': customer.id,
             'partner_shipping_id': customer.id,
             'pricelist_id': pricelist.id,
-            'operating_unit_id': operating_unit.id
+            'operating_unit_id': operating_unit.id,
+            'warehouse_id': warehouse.id
         })
-        self.sale_order_model.sudo(uid).create({
+        self.sale_order_model.create({
             'order_id': sale.id,
             'product_id': product.id,
             'name': 'Sale Order Line'

--- a/sale_operating_unit/views/sale_view.xml
+++ b/sale_operating_unit/views/sale_view.xml
@@ -5,7 +5,7 @@
         <record id="view_quotation_tree" model="ir.ui.view">
             <field name="name">sale.order.tree</field>
             <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_quotation_tree" />
+            <field name="inherit_id" ref="sale.view_quotation_tree"/>
             <field name="arch" type="xml">
                 <field name="user_id" position="after">
                     <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
@@ -16,7 +16,7 @@
         <record id="view_order_tree" model="ir.ui.view">
             <field name="name">sale.order.tree</field>
             <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_tree" />
+            <field name="inherit_id" ref="sale.view_order_tree"/>
             <field name="arch" type="xml">
                 <field name="user_id" position="after">
                     <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
@@ -27,7 +27,7 @@
         <record id="view_order_form" model="ir.ui.view">
             <field name="name">sale.order.form</field>
             <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_order_form" />
+            <field name="inherit_id" ref="sale.view_order_form"/>
             <field name="arch" type="xml">
                 <field name="user_id" position="after">
                     <field name="operating_unit_id" widget="selection" groups="operating_unit.group_multi_operating_unit"/>
@@ -38,7 +38,7 @@
         <record id="view_sales_order_filter" model="ir.ui.view">
             <field name="name">sale.order.list.select</field>
             <field name="model">sale.order</field>
-            <field name="inherit_id" ref="sale.view_sales_order_filter" />
+            <field name="inherit_id" ref="sale.view_sales_order_filter"/>
             <field name="arch" type="xml">
                 <xpath expr="//filter[@string='Salesperson']" position="after">
                     <filter string="Department" domain="[]" groups="operating_unit.group_multi_operating_unit" context="{'group_by':'operating_unit_id'}"/>

--- a/sale_operating_unit/views/sale_view.xml
+++ b/sale_operating_unit/views/sale_view.xml
@@ -1,0 +1,53 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="view_quotation_tree" model="ir.ui.view">
+            <field name="name">sale.order.tree</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_quotation_tree" />
+            <field name="arch" type="xml">
+                <field name="user_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_order_tree" model="ir.ui.view">
+            <field name="name">sale.order.tree</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_tree" />
+            <field name="arch" type="xml">
+                <field name="user_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_order_form" model="ir.ui.view">
+            <field name="name">sale.order.form</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_order_form" />
+            <field name="arch" type="xml">
+                <field name="user_id" position="after">
+                    <field name="operating_unit_id" widget="selection" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_sales_order_filter" model="ir.ui.view">
+            <field name="name">sale.order.list.select</field>
+            <field name="model">sale.order</field>
+            <field name="inherit_id" ref="sale.view_sales_order_filter" />
+            <field name="arch" type="xml">
+                <xpath expr="//filter[@string='Salesperson']" position="after">
+                    <filter string="Department" domain="[]" groups="operating_unit.group_multi_operating_unit" context="{'group_by':'operating_unit_id'}"/>
+                </xpath>
+                <field name="partner_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
## Sales with Operating Units

This module introduces the following features:
- Adds the Operating Unit (OU) to sales orders
- Adds rules to access sales order according user’s OU
- Adds retrictions to avoid creating sales orders where the company is different to the OU
- The OU in the sales order must match the OU in the Warehouse
- By default the main OU is related to a stock location
- By default the default OU is added to the sale order
### Usage

Set a OU for a warehouse and to locations if needed
Create sales orders and delivery orders for specific OUs
