### PR TITLE
[ADD][9.0] purchase request operating unit modules

### DIFF
--- a/oca_dependencies.txt
+++ b/oca_dependencies.txt
@@ -1,0 +1,1 @@
+purchase-workflow

--- a/purchase_request_operating_unit/README.rst
+++ b/purchase_request_operating_unit/README.rst
@@ -1,0 +1,58 @@
+.. image:: https://img.shields.io/badge/license-LGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/lgpl.html
+   :alt: License: LGPL-3
+
+=====================================
+Purchase Request with Operating Units
+=====================================
+
+This module introduces the following features:
+
+* Adds the Operating Unit (OU) to the Purchase Request.
+* The user’s default Operating Unit (OU) is proposed at the time of creating the Purchase Request.
+* Security rules are defined to ensure that users can only see the Purchase Request of that Operating Units in which they are allowed access to.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/operating-unit/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Aaron Henriquez <aheficent@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_request_operating_unit/__init__.py
+++ b/purchase_request_operating_unit/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import model
+from . import tests

--- a/purchase_request_operating_unit/__openerp__.py
+++ b/purchase_request_operating_unit/__openerp__.py
@@ -1,0 +1,22 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Operating Unit in Purchase Requests",
+    "version": "9.0.1.0.0",
+    "author": "Eficent"
+              "Serpent Consulting Services Pvt. Ltd.,"
+              "Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "website": "http://www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase_request",
+                "purchase_operating_unit"],
+    "data": [
+        "view/purchase_request_view.xml",
+        "security/purchase_security.xml",
+    ],
+    'installable': True,
+}

--- a/purchase_request_operating_unit/model/__init__.py
+++ b/purchase_request_operating_unit/model/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import purchase_request

--- a/purchase_request_operating_unit/model/purchase_request.py
+++ b/purchase_request_operating_unit/model/purchase_request.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from openerp import api, fields, models, _
+
+
+class PurchaseRequest(models.Model):
+    _inherit = 'purchase.request'
+
+    operating_unit_id = fields.Many2one(
+        'operating.unit',
+        string='Operating Unit',
+        default=lambda self:
+        self.env['res.users'].
+        operating_unit_default_get(self._uid),
+    )
+
+    @api.multi
+    @api.constrains('operating_unit_id', 'company_id')
+    def _check_company_operating_unit(self):
+        for rec in self:
+            if rec.company_id and rec.operating_unit_id and \
+                    rec.company_id != rec.operating_unit_id.company_id:
+                raise Warning(_("The Company in the Purchase Request and in "
+                                "the Operating Unit must be the same."))
+
+    @api.multi
+    @api.constrains('operating_unit_id', 'picking_type_id')
+    def _check_warehouse_operating_unit(self):
+        for rec in self:
+            picking_type = rec.picking_type_id
+            if picking_type:
+                if picking_type.warehouse_id and\
+                        picking_type.warehouse_id.operating_unit_id\
+                        and rec.operating_unit_id and\
+                        picking_type.warehouse_id.operating_unit_id !=\
+                        rec.operating_unit_id:
+                    raise Warning(_("Configuration error! The Purchase Request"
+                                    " and the Warehouse of picking type must"
+                                    " belong to the same Operating Unit."))
+
+
+class PurchaseRequestLine(models.Model):
+    _inherit = 'purchase.request.line'
+
+    operating_unit_id = fields.Many2one(
+        'operating.unit',
+        related='request_id.operating_unit_id',
+        string='Operating Unit', readonly=True,
+        store=True,
+    )

--- a/purchase_request_operating_unit/security/purchase_security.xml
+++ b/purchase_request_operating_unit/security/purchase_security.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <record id="ir_rule_purchase_request_allowed_operating_units"
+                model="ir.rule">
+            <field name="model_id" ref="purchase_request.model_purchase_request"/>
+            <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+            <field name="name">Purchase Requests from allowed operating units</field>
+            <field name="global" eval="True"/>
+            <field eval="0" name="perm_unlink"/>
+            <field eval="0" name="perm_write"/>
+            <field eval="1" name="perm_read"/>
+            <field eval="0" name="perm_create"/>
+        </record>
+
+        <record id="ir_rule_purchase_request_line_allowed_operating_units"
+                model="ir.rule">
+            <field name="model_id" ref="purchase_request.model_purchase_request_line"/>
+            <field name="domain_force">['|',('request_id.operating_unit_id','=',False),('request_id.operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+            <field name="name">Purchase Requests lines from allowed operating units</field>
+            <field name="global" eval="True"/>
+            <field eval="0" name="perm_unlink"/>
+            <field eval="0" name="perm_write"/>
+            <field eval="1" name="perm_read"/>
+            <field eval="0" name="perm_create"/>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_request_operating_unit/tests/__init__.py
+++ b/purchase_request_operating_unit/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import test_purchase_request_operating_unit

--- a/purchase_request_operating_unit/tests/test_purchase_request_operating_unit.py
+++ b/purchase_request_operating_unit/tests/test_purchase_request_operating_unit.py
@@ -1,0 +1,92 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from openerp.tests import common
+
+
+class TestPurchaseRequestOperatingUnit(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseRequestOperatingUnit, self).setUp()
+        # Models
+        self.res_users_model = self.env['res.users']
+        self.purchase_request = self.env['purchase.request']
+        self.purchase_request_line = self.env['purchase.request.line']
+        # Company
+        self.company = self.env.ref('base.main_company')
+        # Main Operating Unit
+        self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        # B2C Operating Unit
+        self.b2c = self.env.ref('operating_unit.b2c_operating_unit')
+        # Product
+        self.product1 = self.env.ref('product.product_product_7')
+        self.product_uom = self.env.ref('product.product_uom_unit')
+        # User
+        self.user_root = self.env.ref('base.user_root')
+        # Groups
+        self.grp_pr_mngr = self.env.\
+            ref('purchase_request.group_purchase_request_manager')
+        # Picking Type
+        b2c_wh = self.env.ref('stock_operating_unit.stock_warehouse_b2c')
+        self.b2c_type_in_id = b2c_wh.in_type_id.id
+        self.picking_type = self.env.ref('stock.picking_type_in')
+
+        # Creates Users and Purchase request
+        self.user1 = self._create_user(
+            'user_1', [], self.company, [self.ou1])
+        self.user2 = self._create_user(
+            'user_2', self.grp_pr_mngr, self.company, [self.b2c])
+        self.request1 = self._create_purchase_request(self.ou1)
+        self._purchase_line(self.request1)
+        self.request2 = self._create_purchase_request(self.b2c,
+                                                      self.b2c_type_in_id)
+        self._purchase_line(self.request2)
+
+    def _create_user(self, login, groups, company, operating_units,
+                     context=None):
+        """ Create a user. """
+        group_ids = [group.id for group in groups]
+        user = self.res_users_model.create({
+            'name': 'Test Purchase Request User',
+            'login': login,
+            'password': 'demo',
+            'email': 'example@yourcompany.com',
+            'company_id': company.id,
+            'company_ids': [(4, company.id)],
+            'operating_unit_ids': [(4, ou.id) for ou in operating_units],
+            'groups_id': [(6, 0, group_ids)]
+        })
+        return user
+
+    def _purchase_line(self, request):
+        line = self.purchase_request_line.create({
+            'request_id': request.id,
+            'product_id': self.product1.id,
+            'product_uom_id': self.product_uom.id,
+            'product_qty': 5.0,
+        })
+        return line
+
+    def _create_purchase_request(self, operating_unit, picking_type=False):
+        if picking_type:
+            purchase_request = self.purchase_request.create({
+                'assigned_to': self.user_root.id,
+                'picking_type_id': self.b2c_type_in_id,
+                'operating_unit_id': operating_unit.id,
+            })
+        else:
+            purchase_request = self.purchase_request.create({
+                'assigned_to': self.user_root.id,
+                'picking_type_id': self.picking_type.id,
+                'operating_unit_id': operating_unit.id,
+            })
+        return purchase_request
+
+    def test_purchase_request(self):
+        record = self.purchase_request.sudo(self.user2.id).\
+            search([('id', '=', self.request1.id),
+                    ('operating_unit_id', '=', self.ou1.id)])
+        self.assertEqual(record.ids, [], 'User 2 should not have access to '
+                         'OU %s' % self.ou1.name)

--- a/purchase_request_operating_unit/view/purchase_request_view.xml
+++ b/purchase_request_operating_unit/view/purchase_request_view.xml
@@ -1,0 +1,87 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="view_purchase_request_tree" model="ir.ui.view">
+            <field name="name">purchase.request.tree</field>
+            <field name="model">purchase.request</field>
+            <field name="inherit_id" ref="purchase_request.view_purchase_request_tree" />
+            <field name="arch" type="xml">
+                <field name="company_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_purchase_request_form" model="ir.ui.view">
+            <field name="name">purchase.request.form</field>
+            <field name="model">purchase.request</field>
+            <field name="inherit_id" ref="purchase_request.view_purchase_request_form" />
+            <field name="arch" type="xml">
+                <field name="company_id" position="after">
+                  <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
+                </field>
+                <xpath expr="//field[@name='line_ids']" position="attributes">
+                    <attribute name="context">{'operating_unit_id': operating_unit_id}</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_purchase_request_search" model="ir.ui.view">
+          <field name="name">purchase.request.list.select</field>
+          <field name="model">purchase.request</field>
+          <field name="inherit_id" ref="purchase_request.view_purchase_request_search" />
+          <field name="arch" type="xml">
+              <group position="inside">
+                <filter name="operating_unit"
+                      string="Operating Unit" groups="operating_unit.group_multi_operating_unit"
+                      context="{'group_by':'operating_unit_id'}"/>
+              </group>
+              <field name="picking_type_id" position="after">
+                  <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+              </field>
+            </field>
+        </record>
+
+        <record id="purchase_request_line_tree" model="ir.ui.view">
+            <field name="name">purchase.request.line.tree</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id" ref="purchase_request.purchase_request_line_tree" />
+            <field name="arch" type="xml">
+                <field name="supplier_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="purchase_request_line_form" model="ir.ui.view">
+            <field name="name">purchase.request.line.form</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id" ref="purchase_request.purchase_request_line_form" />
+            <field name="arch" type="xml">
+                <field name="date_required" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="purchase_request_line_search" model="ir.ui.view">
+            <field name="name">purchase.request.line.search</field>
+            <field name="model">purchase.request.line</field>
+            <field name="inherit_id" ref="purchase_request.purchase_request_line_search" />
+            <field name="arch" type="xml">
+                <field name="analytic_account_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+                <group position="inside">
+                    <filter name="operating_unit"
+                            string="Operating Unit"
+                            domain="[]"
+                            groups="operating_unit.group_multi_operating_unit"
+                            context="{'group_by':'operating_unit_id'}"/>
+                </group>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_request_procurement_operating_unit/README.rst
+++ b/purchase_request_procurement_operating_unit/README.rst
@@ -1,0 +1,57 @@
+.. image:: https://img.shields.io/badge/license-LGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/lgpl.html
+   :alt: License: LGPL-3
+
+=================================================
+Purchase Request Procurement with Operating Units
+=================================================
+
+This module introduces the following features:
+
+* This module passes the Operating Unit from the Procurement to the Purchase Request and also 
+  ensures that the Purchase Request and the Procurement Order must belong to the same Operating Unit.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/operating-unit/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Aaron Henriquez <aheficent@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_request_procurement_operating_unit/__init__.py
+++ b/purchase_request_procurement_operating_unit/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).

--- a/purchase_request_procurement_operating_unit/__openerp__.py
+++ b/purchase_request_procurement_operating_unit/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Purchase Request Procurement with Operating Units",
+    "version": "9.0.1.0.0",
+    "author": "Eficent"
+              "Serpent Consulting Services Pvt. Ltd.,"
+              "Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "website": "http://www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase_request_procurement",
+                "purchase_request_operating_unit",
+                'procurement_operating_unit'],
+    'installable': True,
+}

--- a/purchase_request_procurement_operating_unit/model/__init__.py
+++ b/purchase_request_procurement_operating_unit/model/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from . import procurement

--- a/purchase_request_procurement_operating_unit/model/procurement.py
+++ b/purchase_request_procurement_operating_unit/model/procurement.py
@@ -1,0 +1,41 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from openerp import models, api, _
+
+
+class Procurement(models.Model):
+    _inherit = 'procurement.order'
+
+    @api.model
+    def _prepare_purchase_request(self, procurement):
+        res = super(Procurement, self)._prepare_purchase_request(procurement)
+        if procurement.location_id.operating_unit_id:
+            res.update({
+                'operating_unit_id':
+                    procurement.location_id.operating_unit_id.id
+            })
+        return res
+
+    @api.multi
+    @api.constrains('location_id', 'request_id')
+    def _check_purchase_request_operating_unit(self):
+        for rec in self:
+            if rec.request_id and rec.location_id.operating_unit_id and \
+                    rec.request_id.operating_unit_id != \
+                    rec.location_id.operating_unit_id:
+                raise Warning(_('The Purchase Request and the Procurement '
+                                'Order must belong to the same Operating'
+                                'Unit.'))
+
+    @api.multi
+    @api.constrains('location_id', 'warehouse_id')
+    def _check_warehouse_operating_unit(self):
+        for rec in self:
+            if rec.warehouse_id and rec.location_id.operating_unit_id and \
+                    rec.warehouse_id.operating_unit_id != \
+                    rec.location_id.operating_unit_id:
+                raise Warning(_('Warehouse and location of procurement order '
+                                'must belong to the same Operating Unit.'))

--- a/purchase_request_procurement_operating_unit/tests/__init__.py
+++ b/purchase_request_procurement_operating_unit/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from . import test_purchase_request_procurement_operating_unit

--- a/purchase_request_procurement_operating_unit/tests/test_purchase_request_procurement_operating_unit.py
+++ b/purchase_request_procurement_operating_unit/tests/test_purchase_request_procurement_operating_unit.py
@@ -1,0 +1,70 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openerp.tests import common
+
+
+class TestProcurement(common.TransactionCase):
+
+    def setUp(self):
+        super(TestProcurement, self).setUp()
+        self.res_users_model = self.env['res.users']
+        self.procurement_order_model = self.env['procurement.order']
+        self.procurement_rule_model = self.env['procurement.rule']
+        self.warehouse = self.env.ref('stock.warehouse0')
+
+        # Main Operating Unit
+        self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        # B2C Operating Unit
+        self.b2c = self.env.ref('operating_unit.b2c_operating_unit')
+
+        # Products
+        self.product1 = self.env.ref('product.product_product_9')
+        self.product1.write({'purchase_request': True})
+
+        # Picking Type
+        b2c_wh = self.env.ref('stock_operating_unit.stock_warehouse_b2c')
+        self.b2c_type_in_id = b2c_wh.in_type_id.id
+        self.picking_type = self.env.ref('stock.picking_type_in')
+
+        self.rule = self._create_procurement_rule()
+        self.procurement_order = self._create_procurement_order()
+
+    def _create_procurement_rule(self):
+        rule = self.procurement_rule_model.\
+            create({'name': 'Procurement rule',
+                    'action': 'buy',
+                    'picking_type_id': self.picking_type.id
+                    })
+        return rule
+
+    def _create_procurement_order(self):
+        # On change for warehouse_id
+        new_line = self.procurement_order_model.new()
+        res = new_line.change_warehouse_id(self.warehouse.id)
+        if res.get('value') and res.get('value').get('location_id'):
+            location_id = res.get('value').get('location_id')
+        # On change for product_id
+        new_line = self.procurement_order_model.new()
+        res = new_line.onchange_product_id(self.product1.id)
+        if res.get('value') and res.get('value').get('product_uom'):
+            product_uom = res.get('value').get('product_uom')
+        proc = self.procurement_order_model.\
+            create({'product_id': self.product1.id,
+                    'product_uom': product_uom,
+                    'product_qty': '10',
+                    'name': 'Procurement Order',
+                    'warehouse_id': self.warehouse.id,
+                    'rule_id': self.rule.id,
+                    'location_id': location_id
+                    })
+        proc.check()
+        proc.run()
+        return proc
+
+    def test_security(self):
+        self.assertEqual(self.procurement_order.location_id.operating_unit_id,
+                         self.procurement_order.request_id.operating_unit_id,
+                         'The Operating Unit in Procurement Order Location'
+                         'does not match to Purchase Request OU.')

--- a/purchase_request_to_requisition_operating_unit/README.rst
+++ b/purchase_request_to_requisition_operating_unit/README.rst
@@ -1,0 +1,56 @@
+.. image:: https://img.shields.io/badge/license-LGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/lgpl.html
+   :alt: License: LGPL-3
+
+======================================================
+Purchase Request to Call for Bids with Operating Units
+======================================================
+
+This module introduces the following features:
+
+* This module pass the Operating Unit from the purchase request to the bid.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/operating-unit/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Aaron Henriquez <aheficent@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_request_to_requisition_operating_unit/__init__.py
+++ b/purchase_request_to_requisition_operating_unit/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import wizard

--- a/purchase_request_to_requisition_operating_unit/__openerp__.py
+++ b/purchase_request_to_requisition_operating_unit/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Purchase Request to Call for Bids with Operating Units",
+    "version": "9.0.1.0.0",
+    "author": "Eficent"
+              "Serpent Consulting Services Pvt. Ltd.,"
+              "Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "website": "http://www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase_request_to_requisition",
+                "purchase_request_operating_unit",
+                "purchase_requisition_operating_unit"],
+    'installable': True,
+}

--- a/purchase_request_to_requisition_operating_unit/tests/__init__.py
+++ b/purchase_request_to_requisition_operating_unit/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import test_purchase_request_to_requisition_operating_unit

--- a/purchase_request_to_requisition_operating_unit/tests/test_purchase_request_to_requisition_operating_unit.py
+++ b/purchase_request_to_requisition_operating_unit/tests/test_purchase_request_to_requisition_operating_unit.py
@@ -1,0 +1,53 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openerp.tests import common
+from openerp.tools import SUPERUSER_ID
+
+
+class TestPurchaseRequestToRequisition(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseRequestToRequisition, self).setUp()
+        self.purchase_request = self.env['purchase.request']
+        self.purchase_request_line_obj = self.env['purchase.request.line']
+        self.wiz =\
+            self.env['purchase.request.line.make.purchase.requisition']
+        self.purchase_requisition_partner_model =\
+            self.env['purchase.requisition.partner']
+        self.purchase_order = self.env['purchase.order']
+        # Main Operating Unit
+        self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        # Products
+        self.product1 = self.env.ref('product.product_product_9')
+        self._create_purchase_request()
+
+    def _create_purchase_request(self):
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+            'operating_unit_id': self.ou1.id
+        }
+        purchase_request = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request.id,
+            'product_id': self.product1.id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 5.0,
+        }
+        self.purchase_request_line =\
+            self.purchase_request_line_obj.create(vals)
+
+    def test_purchase_request_to_purchase_requisition(self):
+        wiz = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[self.purchase_request_line.id],
+            active_id=self.purchase_request_line.id).create({})
+        wiz.make_purchase_requisition()
+        requisition_id =\
+            self.purchase_request_line.requisition_lines.requisition_id
+        self.assertEqual(
+            requisition_id.operating_unit_id,
+            self.purchase_request_line.operating_unit_id,
+            'Should have the same Operating Unit')

--- a/purchase_request_to_requisition_operating_unit/wizard/__init__.py
+++ b/purchase_request_to_requisition_operating_unit/wizard/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from . import purchase_request_line_make_purchase_requisition

--- a/purchase_request_to_requisition_operating_unit/wizard/purchase_request_line_make_purchase_requisition.py
+++ b/purchase_request_to_requisition_operating_unit/wizard/purchase_request_line_make_purchase_requisition.py
@@ -1,0 +1,46 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openerp import api, fields, models, _
+from openerp.exceptions import except_orm
+
+
+class PurchaseRequestLineMakePurchaseRequisition(models.TransientModel):
+    _inherit = "purchase.request.line.make.purchase.requisition"
+
+    operating_unit_id = fields.Many2one(
+        'operating.unit',
+        string='Operating Unit',
+        readonly=True,
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super(PurchaseRequestLineMakePurchaseRequisition, self).\
+            default_get(fields)
+        request_line_obj = self.env['purchase.request.line']
+        request_line_ids = self._context.get('active_ids', [])
+        operating_unit_id = False
+        for line in request_line_obj.browse(request_line_ids):
+            line_operating_unit_id = line.request_id.operating_unit_id \
+                and line.request_id.operating_unit_id.id or False
+            if operating_unit_id\
+                    and line_operating_unit_id != operating_unit_id:
+                raise except_orm(
+                    _('Could not process !'),
+                    _('You have to select lines '
+                      'from the same operating unit.'))
+            else:
+                operating_unit_id = line_operating_unit_id
+        res['operating_unit_id'] = operating_unit_id
+        return res
+
+    @api.model
+    def _prepare_purchase_requisition(self, picking_type_id,
+                                      company_id):
+        res = super(PurchaseRequestLineMakePurchaseRequisition, self).\
+            _prepare_purchase_requisition(picking_type_id, company_id)
+        if self.operating_unit_id:
+            res.update({'operating_unit_id': self.operating_unit_id.id})
+        return res

--- a/purchase_request_to_rfq_operating_unit/README.rst
+++ b/purchase_request_to_rfq_operating_unit/README.rst
@@ -1,0 +1,56 @@
+.. image:: https://img.shields.io/badge/license-LGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/lgpl.html
+   :alt: License: LGPL-3
+
+============================================
+Purchase Request to RFQ with Operating Units
+============================================
+
+This module introduces the following features:
+
+* This module pass the Operating Unit from the purchase request to the RFQ.
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/operating-unit/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Jordi Ballester Alomar <jordi.ballester@eficent.com>
+* Aaron Henriquez <aheficent@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_request_to_rfq_operating_unit/__init__.py
+++ b/purchase_request_to_rfq_operating_unit/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import wizard

--- a/purchase_request_to_rfq_operating_unit/__openerp__.py
+++ b/purchase_request_to_rfq_operating_unit/__openerp__.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+{
+    "name": "Purchase Request to RFQ with Operating Units",
+    "version": "9.0.1.0.0",
+    "author": "Eficent"
+              "Serpent Consulting Services Pvt. Ltd.,"
+              "Odoo Community Association (OCA)",
+    "license": "LGPL-3",
+    "website": "http://www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase_request_to_rfq", "purchase_request_operating_unit"],
+    "data": [
+        "wizard/purchase_request_line_make_purchase_order_view.xml",
+    ],
+    'installable': True,
+}

--- a/purchase_request_to_rfq_operating_unit/tests/__init__.py
+++ b/purchase_request_to_rfq_operating_unit/tests/__init__.py
@@ -1,0 +1,5 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from . import test_purchase_request_to_rfq_operating_unit

--- a/purchase_request_to_rfq_operating_unit/tests/test_purchase_request_to_rfq_operating_unit.py
+++ b/purchase_request_to_rfq_operating_unit/tests/test_purchase_request_to_rfq_operating_unit.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openerp.tests import common
+from openerp.tools import SUPERUSER_ID
+
+
+class TestPurchaseRequestToRfq(common.TransactionCase):
+
+    def setUp(self):
+        super(TestPurchaseRequestToRfq, self).setUp()
+        self.purchase_request = self.env['purchase.request']
+        self.purchase_request_line = self.env['purchase.request.line']
+        self.wiz =\
+            self.env['purchase.request.line.make.purchase.order']
+        self.purchase_order = self.env['purchase.order']
+        # Main Operating Unit
+        self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        # Products
+        self.product1 = self.env.ref('product.product_product_9')
+        self._create_purchase_request()
+
+    def _create_purchase_request(self):
+        vals = {
+            'picking_type_id': self.env.ref('stock.picking_type_in').id,
+            'requested_by': SUPERUSER_ID,
+            'operating_unit_id': self.ou1.id
+        }
+        purchase_request = self.purchase_request.create(vals)
+        vals = {
+            'request_id': purchase_request.id,
+            'product_id': self.product1.id,
+            'product_uom_id': self.env.ref('product.product_uom_unit').id,
+            'product_qty': 5.0,
+        }
+        self.purchase_request_line = self.purchase_request_line.create(vals)
+        purchase_request.button_to_approve()
+        purchase_request.button_approved()
+
+    def test_purchase_request_to_purchase_requisition(self):
+        vals = {'supplier_id': self.env.ref('base.res_partner_12').id}
+        wiz_id = self.wiz.with_context(
+            active_model="purchase.request.line",
+            active_ids=[self.purchase_request_line.id],
+            active_id=self.purchase_request_line.id,).create(vals)
+        wiz_id.make_purchase_order()
+        purchase_id = self.purchase_request_line.purchase_lines.order_id
+        self.assertEqual(
+            purchase_id.operating_unit_id,
+            self.purchase_request_line.operating_unit_id,
+            'Should have the same Operating Unit')

--- a/purchase_request_to_rfq_operating_unit/wizard/__init__.py
+++ b/purchase_request_to_rfq_operating_unit/wizard/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import purchase_request_line_make_purchase_order

--- a/purchase_request_to_rfq_operating_unit/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_to_rfq_operating_unit/wizard/purchase_request_line_make_purchase_order.py
@@ -1,0 +1,50 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from openerp import fields, models, api, _
+from openerp.exceptions import except_orm
+
+
+class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
+    _inherit = "purchase.request.line.make.purchase.order"
+
+    operating_unit_id = fields.Many2one(
+        'operating.unit',
+        string='Operating Unit',
+        readonly=True,
+    )
+
+    @api.model
+    def default_get(self, fields):
+        res = super(PurchaseRequestLineMakePurchaseOrder, self).\
+            default_get(fields)
+        request_line_obj = self.env['purchase.request.line']
+        request_line_ids = self._context.get('active_ids', [])
+        operating_unit_id = False
+        for line in request_line_obj.browse(request_line_ids):
+            line_operating_unit_id = line.request_id.operating_unit_id \
+                and line.request_id.operating_unit_id.id or False
+            if operating_unit_id\
+                    and line_operating_unit_id != operating_unit_id:
+                raise except_orm(
+                    _('Could not process !'),
+                    _('You have to select lines '
+                      'from the same operating unit.'))
+            else:
+                operating_unit_id = line_operating_unit_id
+        res['operating_unit_id'] = operating_unit_id
+        return res
+
+    @api.model
+    def _prepare_purchase_order(self, picking_type, location, company_id):
+        data = super(PurchaseRequestLineMakePurchaseOrder, self).\
+            _prepare_purchase_order(picking_type, location, company_id)
+        if self.operating_unit_id:
+            data['requesting_operating_unit_id'] = \
+                self.operating_unit_id.id
+            data['operating_unit_id'] = \
+                self.operating_unit_id.id
+        return data

--- a/purchase_request_to_rfq_operating_unit/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request_to_rfq_operating_unit/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+        <record id="view_purchase_request_line_make_purchase_order" model="ir.ui.view">
+            <field name="name">Purchase Request Line Make Purchase Order</field>
+            <field name="model">purchase.request.line.make.purchase.order</field>
+            <field name="inherit_id"
+                   ref="purchase_request_to_rfq.view_purchase_request_line_make_purchase_order"/>
+            <field name="type">form</field>
+            <field name="arch" type="xml">
+                 <field name="item_ids" position="before">
+                     <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                 </field>
+                 <field name="purchase_order_id" position="attributes">
+                     <attribute name="domain">['|', ('operating_unit_id', '=', False), ('operating_unit_id', '=', operating_unit_id)]</attribute>
+                 </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>
+


### PR DESCRIPTION
Those modules introduces the Operating units to the purchase request modules https://github.com/OCA/purchase-workflow/tree/9.0/purchase_request, the most important are:

Introduce the operating unit to the purchase request
Pass the Operating Unit from the Procurement to the Purchase Request.
Pass the Operating Unit from the purchase request to the bid.
Pass the Operating Unit from the purchase request to the RFQ.
Security rules for purchase request of specific operating units


