### PR TITLE
[MIG] account_operating_unit to v10.0

### DIFF
--- a/account_operating_unit/README.rst
+++ b/account_operating_unit/README.rst
@@ -30,7 +30,7 @@ Units (OU's).
   create the invoice for.
 
 * Adds the Operating Unit (OU) to payments and payment methods. The operating
-  unit of a payment will be that of the payment method choosen.
+  unit of a payment will be that of the payment method chosen.
 
 * Implements security rules at OU level to invoices, payments and journal
   items.
@@ -85,7 +85,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/213/9.0
+   :target: https://runbot.odoo-community.org/runbot/213/10.0
 
 Known issues / Roadmap
 ======================

--- a/account_operating_unit/__init__.py
+++ b/account_operating_unit/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import models

--- a/account_operating_unit/__manifest__.py
+++ b/account_operating_unit/__manifest__.py
@@ -1,16 +1,16 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     "name": 'Accounting with Operating Units',
     "summary": "Introduces Operating Unit fields in invoices and "
                "Accounting Entries with clearing account",
-    "version": "9.0.1.0.0",
-    "author": "Eficent Business and IT Consulting Services S.L., "
+    "version": "10.0.1.0.0",
+    "author": "Eficent, "
               "Serpent Consulting Services Pvt. Ltd.,"
               "Odoo Community Association (OCA)",
-    "website": "http://www.eficent.com",
+    "website": "https://github.com/OCA/operating-unit",
     "category": "Accounting & Finance",
     "depends": ['account', 'operating_unit'],
     "license": "LGPL-3",
@@ -28,5 +28,5 @@
         "wizard/account_financial_report_view.xml",
         "wizard/account_report_trial_balance_view.xml",
     ],
-    'installable': False,
+    'installable': True,
 }

--- a/account_operating_unit/models/__init__.py
+++ b/account_operating_unit/models/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import company

--- a/account_operating_unit/models/account_journal.py
+++ b/account_operating_unit/models/account_journal.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import api, fields, models, _

--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp.tools.translate import _

--- a/account_operating_unit/models/account_payment.py
+++ b/account_operating_unit/models/account_payment.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import api, fields, models, _

--- a/account_operating_unit/models/company.py
+++ b/account_operating_unit/models/company.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import api, fields, models

--- a/account_operating_unit/models/invoice.py
+++ b/account_operating_unit/models/invoice.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import api, fields, models

--- a/account_operating_unit/report/__init__.py
+++ b/account_operating_unit/report/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import account_invoice_report

--- a/account_operating_unit/report/account_invoice_report.py
+++ b/account_operating_unit/report/account_invoice_report.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import fields, models

--- a/account_operating_unit/security/account_security.xml
+++ b/account_operating_unit/security/account_security.xml
@@ -1,77 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data noupdate="1">
+<odoo noupdate="1">
+
+    <record id="ir_rule_account_journal_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id" ref="account.model_account_journal"/>
+        <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">Journals from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+
+    <record id="ir_rule_invoice_allowed_operating_units" model="ir.rule">
+        <field name="model_id" ref="account.model_account_invoice"/>
+        <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">Invoices from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+
+    <record id="ir_rule_invoice_line_allowed_operating_units" model="ir.rule">
+        <field name="model_id" ref="account.model_account_invoice_line"/>
+        <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">Invoice lines from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+
+    <record id="ir_rule_move_line_allowed_operating_units" model="ir.rule">
+        <field name="model_id" ref="account.model_account_move_line"/>
+        <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">Move lines from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+
+    <record id="ir_rule_account_payment_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id" ref="account.model_account_payment"/>
+        <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">Payments from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
 
 
-        <record id="ir_rule_account_journal_allowed_operating_units"
-                model="ir.rule">
-            <field name="model_id" ref="account.model_account_journal"/>
-            <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
-            <field name="name">Journals from allowed operating units</field>
-            <field name="global" eval="True"/>
-            <field eval="0" name="perm_unlink"/>
-            <field eval="0" name="perm_write"/>
-            <field eval="1" name="perm_read"/>
-            <field eval="0" name="perm_create"/>
-        </record>
+    <record id="ir_rule_invoice_report_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id" ref="account.model_account_invoice_report"/>
+        <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="name">Invoice Report from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
 
-        <record id="ir_rule_invoice_allowed_operating_units" model="ir.rule">
-            <field name="model_id" ref="account.model_account_invoice"/>
-            <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
-            <field name="name">Invoices from allowed operating units</field>
-            <field name="global" eval="True"/>
-            <field eval="0" name="perm_unlink"/>
-            <field eval="0" name="perm_write"/>
-            <field eval="1" name="perm_read"/>
-            <field eval="0" name="perm_create"/>
-        </record>
-
-        <record id="ir_rule_invoice_line_allowed_operating_units" model="ir.rule">
-            <field name="model_id" ref="account.model_account_invoice_line"/>
-            <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
-            <field name="name">Invoice lines from allowed operating units</field>
-            <field name="global" eval="True"/>
-            <field eval="0" name="perm_unlink"/>
-            <field eval="0" name="perm_write"/>
-            <field eval="1" name="perm_read"/>
-            <field eval="0" name="perm_create"/>
-        </record>
-
-        <record id="ir_rule_move_line_allowed_operating_units" model="ir.rule">
-            <field name="model_id" ref="account.model_account_move_line"/>
-            <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
-            <field name="name">Move lines from allowed operating units</field>
-            <field name="global" eval="True"/>
-            <field eval="0" name="perm_unlink"/>
-            <field eval="0" name="perm_write"/>
-            <field eval="1" name="perm_read"/>
-            <field eval="0" name="perm_create"/>
-        </record>
-
-        <record id="ir_rule_account_payment_allowed_operating_units"
-                model="ir.rule">
-            <field name="model_id" ref="account.model_account_payment"/>
-            <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
-            <field name="name">Payments from allowed operating units</field>
-            <field name="global" eval="True"/>
-            <field eval="0" name="perm_unlink"/>
-            <field eval="0" name="perm_write"/>
-            <field eval="1" name="perm_read"/>
-            <field eval="0" name="perm_create"/>
-        </record>
-
-
-        <record id="ir_rule_invoice_report_allowed_operating_units"
-                model="ir.rule">
-            <field name="model_id" ref="account.model_account_invoice_report"/>
-            <field name="domain_force">['|', ('operating_unit_id','=',False), ('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
-            <field name="name">Invoice Report from allowed operating units</field>
-            <field name="global" eval="True"/>
-            <field eval="0" name="perm_unlink"/>
-            <field eval="0" name="perm_write"/>
-            <field eval="1" name="perm_read"/>
-            <field eval="0" name="perm_create"/>
-        </record>
-
-    </data>
-</openerp>
+</odoo>

--- a/account_operating_unit/tests/__init__.py
+++ b/account_operating_unit/tests/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import test_account_operating_unit

--- a/account_operating_unit/tests/test_account_operating_unit.py
+++ b/account_operating_unit/tests/test_account_operating_unit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp.addons.account.tests import account_test_classes

--- a/account_operating_unit/tests/test_account_operating_unit.py
+++ b/account_operating_unit/tests/test_account_operating_unit.py
@@ -2,10 +2,10 @@
 # © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from openerp.addons.account.tests import account_test_classes
+from odoo.addons.account.tests.account_test_classes import AccountingTestCase
 
 
-class TestAccountOperatingUnit(account_test_classes.AccountingTestCase):
+class TestAccountOperatingUnit(AccountingTestCase):
 
     def setUp(self):
         super(TestAccountOperatingUnit, self).setUp()

--- a/account_operating_unit/tests/test_cross_ou_journal_entry.py
+++ b/account_operating_unit/tests/test_cross_ou_journal_entry.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import test_account_operating_unit as test_ou

--- a/account_operating_unit/tests/test_invoice_operating_unit.py
+++ b/account_operating_unit/tests/test_invoice_operating_unit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import test_account_operating_unit as test_ou

--- a/account_operating_unit/tests/test_invoice_operating_unit.py
+++ b/account_operating_unit/tests/test_invoice_operating_unit.py
@@ -17,7 +17,7 @@ class TestInvoiceOperatingUnit(test_ou.TestAccountOperatingUnit):
             self.invoice_model.sudo(self.user_id.id).create(
                 self._prepare_invoice(self.b2b.id))
         # Validate the invoice
-        self.invoice.sudo(self.user_id.id).signal_workflow('invoice_open')
+        self.invoice.sudo(self.user_id.id).action_invoice_open()
         # Check Operating Units in journal entries
         all_op_units = all(move_line.operating_unit_id.id == self.b2b.id for
                            move_line in self.invoice.move_id.line_ids)

--- a/account_operating_unit/tests/test_operating_unit_security.py
+++ b/account_operating_unit/tests/test_operating_unit_security.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import test_account_operating_unit as test_ou

--- a/account_operating_unit/tests/test_payment_operating_unit.py
+++ b/account_operating_unit/tests/test_payment_operating_unit.py
@@ -16,7 +16,7 @@ class TestInvoiceOperatingUnit(test_ou.TestAccountOperatingUnit):
         self.invoice = self.invoice_model.sudo(self.user_id.id).create(
             self._prepare_invoice(self.b2b.id))
         # Validate the invoice
-        self.invoice.sudo(self.user_id.id).signal_workflow('invoice_open')
+        self.invoice.sudo(self.user_id.id).action_invoice_open()
 
         # Pay the invoice using a cash journal associated to the main company
         ctx = {'active_model': 'account.invoice', 'active_ids': [

--- a/account_operating_unit/tests/test_payment_operating_unit.py
+++ b/account_operating_unit/tests/test_payment_operating_unit.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp.addons.account_operating_unit.tests import\

--- a/account_operating_unit/views/account_invoice_report_view.xml
+++ b/account_operating_unit/views/account_invoice_report_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-<data>
+<odoo>
 
     <record id="view_account_invoice_report_search" model="ir.ui.view">
         <field name="name">account.invoice.report.search</field>
@@ -21,5 +20,4 @@
         </field>
     </record>
 
-</data>
-</openerp>
+</odoo>

--- a/account_operating_unit/views/account_journal_view.xml
+++ b/account_operating_unit/views/account_journal_view.xml
@@ -1,20 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="view_account_journal_form" model="ir.ui.view">
-            <field name="name">account.journal.form</field>
-            <field name="model">account.journal</field>
-            <field name="inherit_id" ref="account.view_account_journal_form"/>
-            <field name="arch" type="xml">
-                <field name="company_id" position="after">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           groups="operating_unit.group_multi_operating_unit"
-                           attrs="{'invisible':[('type','not in', ['bank', 'cash'])]}"/>
-                </field>
+    <record id="view_account_journal_form" model="ir.ui.view">
+        <field name="name">account.journal.form</field>
+        <field name="model">account.journal</field>
+        <field name="inherit_id" ref="account.view_account_journal_form"/>
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       groups="operating_unit.group_multi_operating_unit"
+                       attrs="{'invisible':[('type','not in', ['bank', 'cash'])]}"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/account_operating_unit/views/account_move_view.xml
+++ b/account_operating_unit/views/account_move_view.xml
@@ -1,76 +1,74 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="view_move_line_form" model="ir.ui.view">
-            <field name="name">account.move.line.form</field>
-            <field name="model">account.move.line</field>
-            <field name="inherit_id" ref="account.view_move_line_form"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='account_id']" position="after">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           groups="operating_unit.group_multi_operating_unit"/>
-                </xpath>
+    <record id="view_move_line_form" model="ir.ui.view">
+        <field name="name">account.move.line.form</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_form"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='account_id']" position="after">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       groups="operating_unit.group_multi_operating_unit"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_move_line_form2" model="ir.ui.view">
+        <field name="name">account.move.line.form2</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_form2"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='account_id']" position="after">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       groups="operating_unit.group_multi_operating_unit"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_move_line_tree" model="ir.ui.view">
+        <field name="name">account.move.line.tree</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tree"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='account_id']" position="after">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       groups="operating_unit.group_multi_operating_unit"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_account_move_line_filter" model="ir.ui.view">
+        <field name="name">Journal Items</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_account_move_line_filter"/>
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='account_id']" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                <filter string="Operating Unit"  icon="terp-folder-green"
+                        context="{'group_by':'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit"/>
+            </xpath>
+        </field>
+    </record>
+
+
+    <record id="view_move_form" model="ir.ui.view">
+        <field name="name">account.move.form</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_move_form"/>
+        <field name="arch" type="xml">
+            <field name="journal_id" position="after">
+                <field name="operating_unit_id"/>
             </field>
-        </record>
+            <xpath expr="//field[@name='line_ids']/tree//field[@name='account_id']"
+                   position="after">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       groups="operating_unit.group_multi_operating_unit"/>
+            </xpath>
+        </field>
+    </record>
 
-        <record id="view_move_line_form2" model="ir.ui.view">
-            <field name="name">account.move.line.form2</field>
-            <field name="model">account.move.line</field>
-            <field name="inherit_id" ref="account.view_move_line_form2"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='account_id']" position="after">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           groups="operating_unit.group_multi_operating_unit"/>
-                </xpath>
-            </field>
-        </record>
-
-        <record id="view_move_line_tree" model="ir.ui.view">
-            <field name="name">account.move.line.tree</field>
-            <field name="model">account.move.line</field>
-            <field name="inherit_id" ref="account.view_move_line_tree"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='account_id']" position="after">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           groups="operating_unit.group_multi_operating_unit"/>
-                </xpath>
-            </field>
-        </record>
-
-        <record id="view_account_move_line_filter" model="ir.ui.view">
-            <field name="name">Journal Items</field>
-            <field name="model">account.move.line</field>
-            <field name="inherit_id" ref="account.view_account_move_line_filter"/>
-            <field name="arch" type="xml">
-                <xpath expr="//field[@name='account_id']" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                    <filter string="Operating Unit"  icon="terp-folder-green"
-                            context="{'group_by':'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit"/>
-                </xpath>
-            </field>
-        </record>
-
-
-        <record id="view_move_form" model="ir.ui.view">
-            <field name="name">account.move.form</field>
-            <field name="model">account.move</field>
-            <field name="inherit_id" ref="account.view_move_form"/>
-            <field name="arch" type="xml">
-                <field name="journal_id" position="after">
-                    <field name="operating_unit_id"/>
-                </field>
-                <xpath expr="//field[@name='line_ids']/tree//field[@name='account_id']"
-                       position="after">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           groups="operating_unit.group_multi_operating_unit"/>
-                </xpath>
-            </field>
-        </record>
-
-    </data>
-</openerp>
+</odoo>

--- a/account_operating_unit/views/account_payment_view.xml
+++ b/account_operating_unit/views/account_payment_view.xml
@@ -1,61 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="view_account_payment_tree" model="ir.ui.view">
-            <field name="name">account.payment.tree</field>
-            <field name="model">account.payment</field>
-            <field name="inherit_id" ref="account.view_account_payment_tree"/>
-            <field name="arch" type="xml">
-                <field name="journal_id" position="after">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="view_account_payment_tree" model="ir.ui.view">
+        <field name="name">account.payment.tree</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_tree"/>
+        <field name="arch" type="xml">
+            <field name="journal_id" position="after">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="view_account_supplier_payment_tree" model="ir.ui.view">
-            <field name="name">account.supplier.payment.tree</field>
-            <field name="model">account.payment</field>
-            <field name="inherit_id" ref="account.view_account_supplier_payment_tree"/>
-            <field name="arch" type="xml">
-                <field name="journal_id" position="before">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="view_account_supplier_payment_tree" model="ir.ui.view">
+        <field name="name">account.supplier.payment.tree</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_supplier_payment_tree"/>
+        <field name="arch" type="xml">
+            <field name="journal_id" position="before">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="view_account_payment_search" model="ir.ui.view">
-            <field name="name">account.payment.search</field>
-            <field name="model">account.payment</field>
-            <field name="inherit_id" ref="account.view_account_payment_search"/>
-            <field name="arch" type="xml">
-                <field name="journal_id" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
-                <field name="journal_id" position="after">
-                    <filter string="Operating Unit" domain="[]"
-                            context="{'group_by': 'operating_unit_id'}"
-                            groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="view_account_payment_search" model="ir.ui.view">
+        <field name="name">account.payment.search</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_search"/>
+        <field name="arch" type="xml">
+            <field name="journal_id" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
-
-
-        <record id="view_account_payment_form" model="ir.ui.view">
-            <field name="name">account.payment.form</field>
-            <field name="model">account.payment</field>
-            <field name="inherit_id" ref="account.view_account_payment_form"/>
-            <field name="arch" type="xml">
-                <field name="journal_id" position="after">
-                    <field name="operating_unit_id"
-                           groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+            <field name="journal_id" position="after">
+                <filter string="Operating Unit" domain="[]"
+                        context="{'group_by': 'operating_unit_id'}"
+                        groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
-</openerp>
+
+    <record id="view_account_payment_form" model="ir.ui.view">
+        <field name="name">account.payment.form</field>
+        <field name="model">account.payment</field>
+        <field name="inherit_id" ref="account.view_account_payment_form"/>
+        <field name="arch" type="xml">
+            <field name="journal_id" position="after">
+                <field name="operating_unit_id"
+                       groups="operating_unit.group_multi_operating_unit"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/account_operating_unit/views/company_view.xml
+++ b/account_operating_unit/views/company_view.xml
@@ -6,10 +6,12 @@
         <field name="model">res.company</field>
         <field name="inherit_id" ref="base.view_company_form" />
         <field name="arch" type="xml">
-            <group name="account_grp" position="inside">
-                <field name="ou_is_self_balanced"/>
-                <field name="inter_ou_clearing_account_id" />
-            </group>
+            <xpath expr="//notebook/page/group" position="after">
+                <group string="Operating Units">
+                    <field name="ou_is_self_balanced"/>
+                    <field name="inter_ou_clearing_account_id" />
+                </group>
+            </xpath>
         </field>
     </record>
 

--- a/account_operating_unit/views/company_view.xml
+++ b/account_operating_unit/views/company_view.xml
@@ -1,18 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="view_company_form" model="ir.ui.view">
-            <field name="name">res.company.form</field>
-            <field name="model">res.company</field>
-            <field name="inherit_id" ref="base.view_company_form" />
-            <field name="arch" type="xml">
-                <group name="account_grp" position="inside">
-                    <field name="ou_is_self_balanced"/>
-                    <field name="inter_ou_clearing_account_id" />
-                </group>
-            </field>
-        </record>
+    <record id="view_company_form" model="ir.ui.view">
+        <field name="name">res.company.form</field>
+        <field name="model">res.company</field>
+        <field name="inherit_id" ref="base.view_company_form" />
+        <field name="arch" type="xml">
+            <group name="account_grp" position="inside">
+                <field name="ou_is_self_balanced"/>
+                <field name="inter_ou_clearing_account_id" />
+            </group>
+        </field>
+    </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/account_operating_unit/views/invoice_view.xml
+++ b/account_operating_unit/views/invoice_view.xml
@@ -1,61 +1,59 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
-        <record id="invoice_tree" model="ir.ui.view">
-            <field name="name">account.invoice.tree</field>
-            <field name="model">account.invoice</field>
-            <field name="inherit_id" ref="account.invoice_tree" />
-            <field name="arch" type="xml">
-                <field name="company_id" position="before">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           groups="operating_unit.group_multi_operating_unit"/>
-                </field>
-          </field>
-        </record>
-
-        <record id="view_account_invoice_filter" model="ir.ui.view">
-            <field name="name">account.invoice.select</field>
-            <field name="model">account.invoice</field>
-            <field name="inherit_id" ref="account.view_account_invoice_filter" />
-            <field name="arch" type="xml">
-                <field name="user_id" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
-                <filter name="group_by_partner_id" position="after">
-                    <filter string="Operating Unit" icon="terp-folder-orange"
-                          domain="[]" groups="operating_unit.group_multi_operating_unit"
-                          context="{'group_by':'operating_unit_id'}"/>
-                </filter>
+    <record id="invoice_tree" model="ir.ui.view">
+        <field name="name">account.invoice.tree</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_tree" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="before">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+      </field>
+    </record>
 
-        <record id="invoice_supplier_form" model="ir.ui.view">
-            <field name="name">account.invoice.supplier.form</field>
-            <field name="model">account.invoice</field>
-            <field name="inherit_id" ref="account.invoice_supplier_form" />
-            <field name="arch" type="xml">
-                <field name="journal_id" position="before">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           widget="selection" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="view_account_invoice_filter" model="ir.ui.view">
+        <field name="name">account.invoice.select</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.view_account_invoice_filter" />
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+            <filter name="group_by_partner_id" position="after">
+                <filter string="Operating Unit" icon="terp-folder-orange"
+                      domain="[]" groups="operating_unit.group_multi_operating_unit"
+                      context="{'group_by':'operating_unit_id'}"/>
+            </filter>
+        </field>
+    </record>
 
-        <record id="invoice_form" model="ir.ui.view">
-            <field name="name">account.invoice.form</field>
-            <field name="model">account.invoice</field>
-            <field name="inherit_id" ref="account.invoice_form" />
-            <field name="arch" type="xml">
-                <field name="journal_id" position="before">
-                    <field name="operating_unit_id"
-                           options="{'no_create': True}"
-                           widget="selection" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="invoice_supplier_form" model="ir.ui.view">
+        <field name="name">account.invoice.supplier.form</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_supplier_form" />
+        <field name="arch" type="xml">
+            <field name="journal_id" position="before">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       widget="selection" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
-</openerp>
+    <record id="invoice_form" model="ir.ui.view">
+        <field name="name">account.invoice.form</field>
+        <field name="model">account.invoice</field>
+        <field name="inherit_id" ref="account.invoice_form" />
+        <field name="arch" type="xml">
+            <field name="journal_id" position="before">
+                <field name="operating_unit_id"
+                       options="{'no_create': True}"
+                       widget="selection" groups="operating_unit.group_multi_operating_unit"/>
+            </field>
+        </field>
+    </record>
+
+</odoo>

--- a/account_operating_unit/views/report_agedpartnerbalance.xml
+++ b/account_operating_unit/views/report_agedpartnerbalance.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
     <template id="report_agedpartnerbalance_operating_units"
               inherit_id="account.report_agedpartnerbalance">
         <xpath expr="//div[@class='row mt32']" position="inside">
@@ -9,4 +10,5 @@
             </div>
         </xpath>
     </template>
+
 </odoo>

--- a/account_operating_unit/views/report_financial.xml
+++ b/account_operating_unit/views/report_financial.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
     <template id="report_financial_operating_units"
               inherit_id="account.report_financial">
         <xpath expr="//div[@class='row mt32 mb32']" position="inside">
@@ -9,4 +10,5 @@
             </div>
         </xpath>
     </template>
+
 </odoo>

--- a/account_operating_unit/views/report_trialbalance.xml
+++ b/account_operating_unit/views/report_trialbalance.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
+
     <template id="report_trialbalance_operating_units"
               inherit_id="account.report_trialbalance">
         <xpath expr="//div[@class='row mt32']" position="inside">
@@ -9,4 +10,5 @@
             </div>
         </xpath>
     </template>
+
 </odoo>

--- a/account_operating_unit/wizard/__init__.py
+++ b/account_operating_unit/wizard/__init__.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import account_report_common

--- a/account_operating_unit/wizard/account_financial_report.py
+++ b/account_operating_unit/wizard/account_financial_report.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import fields, models

--- a/account_operating_unit/wizard/account_financial_report_view.xml
+++ b/account_operating_unit/wizard/account_financial_report_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-     <data>
+<odoo>
 
         <record id="accounting_report_view" model="ir.ui.view">
             <field name="name">Accounting Report</field>
@@ -19,5 +18,4 @@
             </field>
         </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/account_operating_unit/wizard/account_report_common.py
+++ b/account_operating_unit/wizard/account_report_common.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import fields, models

--- a/account_operating_unit/wizard/account_report_common_view.xml
+++ b/account_operating_unit/wizard/account_report_common_view.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<openerp>
-    <data>
+<odoo>
 
         <record id="account_common_report_view" model="ir.ui.view">
             <field name="name">Common Report</field>
@@ -14,5 +13,4 @@
             </field>
         </record>
 
-    </data>
-</openerp>
+</odoo>

--- a/account_operating_unit/wizard/account_report_trial_balance.py
+++ b/account_operating_unit/wizard/account_report_trial_balance.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import fields, models


### PR DESCRIPTION
Accounting with Operating Units
===============================

This module allows a company to manage the accounting based on Operating
Units (OU's).

* The financial reports (Trial Balance, P&L, Balance Sheet), allow to report
  the balances of one or more OU's.

* If a company wishes to report Balance Sheet and P&L accounts based on
  OU's, they should indicate at company level that the OU's are
  self-balanced, and the corresponding Inter-Operating Unit clearing account.
  The Chart of Accounts will always be balanced, for each Operating Unit.

* A company considering Operating Unit as applicable to report only profits
  and losses will not need to set the OU's as self-balanced.

* The self-balancing of Operating Unit is ensured at the time of posting a
  journal entry. In case that the journal involves posting of items in
  separate Operating Units, new journal items will be created, using the
  Inter-Operating Unit clearing account, to ensure that each OU is going to
  be self-balanced for that journal entry.

* Adds the Operating Unit (OU) to the invoice. A user can choose what OU to
  create the invoice for.

* Adds the Operating Unit (OU) to payments and payment methods. The operating
  unit of a payment will be that of the payment method choosen.

* Implements security rules at OU level to invoices, payments and journal
  items.