### PR TITLE
[FIX][10.0]Singleton error when paying more than one invoice

### DIFF
--- a/account_operating_unit/models/account_payment.py
+++ b/account_operating_unit/models/account_payment.py
@@ -22,7 +22,7 @@ class AccountPayment(models.Model):
     def _get_counterpart_move_line_vals(self, invoice=False):
         res = super(AccountPayment,
                     self)._get_counterpart_move_line_vals(invoice=invoice)
-        if invoice:
+        if len(invoice) == 1:
             res['operating_unit_id'] = invoice.operating_unit_id.id or False
         else:
             res['operating_unit_id'] = self.operating_unit_id.id or False


### PR DESCRIPTION
I suggest to consider the OU of the invoice when there's just one invoice. Otherwise the OU of the journal is considered.