### PR TITLE
[9.0][FIX]operating unit when onchange picking type

### DIFF
--- a/stock_operating_unit/model/stock.py
+++ b/stock_operating_unit/model/stock.py
@@ -48,14 +48,6 @@ class StockLocation(models.Model):
                     raise UserError(_('Configuration error\nThis location is '
                                       'assigned to a warehouse that belongs to'
                                       ' a different operating unit.'))
-                if self.operating_unit_id != w.operating_unit_id:
-                    raise UserError(_('Configuration error\nThis location is '
-                                      'assigned to a warehouse that belongs to'
-                                      ' a different operating unit.'))
-                if rec.operating_unit_id != w.operating_unit_id:
-                    raise UserError(_('Configuration error\nThis location is'
-                                      ' assigned to a warehouse that belongs'
-                                      ' to a different operating unit.'))
 
     @api.multi
     @api.constrains('operating_unit_id')
@@ -102,8 +94,7 @@ class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
     operating_unit_id = fields.Many2one('operating.unit',
-                                        'Requesting Operating Unit',
-                                        readonly=1)
+                                        'Requesting Operating Unit')
 
     @api.v7
     def onchange_picking_type(self, cr, uid, ids, picking_type_id, partner_id,


### PR DESCRIPTION
The onchange method is not compatible with readonly fields. 

When changing the picking type the operating unit of the warehouse was not been stored.

As there's  a constraint that checks for incompatibilities between the operating unit in the warehouse and in the picking I think the field operating_unit_id in the picking can be editable.

This PR Includes another small fix in the method  `_check_warehouse_operating_unit`