### PR TITLE
[10.0] [ADD] purchase_requisition_operating_unit

### DIFF
--- a/purchase_requisition_operating_unit/README.rst
+++ b/purchase_requisition_operating_unit/README.rst
@@ -10,11 +10,11 @@ This module introduces the following features:
 
 * Security rules are defined to ensure that users can only see the Purchase Requisition of that Operating Units in which they are allowed access to.
 
-* Ensures that Operating Unit in Purchase Requisition and the Warehouse of picking type belongs to the same Operating Unit.
+* Ensures that Purchase Requisition and the Warehouse in picking type belongs to the same Operating Unit (OU) .
 
-* When the user creates a Purchase Order (PO) from the purchase requisition the operating unit is copied to that PO.
+* When the user creates a Purchase Order (PO) from the purchase requisition the operating unit is passed to that PO.
 
-* Sets default Picking type having Operating Unit (OU) in Warehouse that of the User.
+* Sets default Picking type whoes Operating Unit (OU) in Warehouse matches to that of the User.
 
 
 Installation

--- a/purchase_requisition_operating_unit/README.rst
+++ b/purchase_requisition_operating_unit/README.rst
@@ -8,16 +8,13 @@ Purchase Requisition with Operating Units
 
 This module introduces the following features:
 
-* Adds Operating Unit (OU) to the account moves and its lines created by the payslip, based on the Operating Unit (OU) defined in the Employee's Contract.
-
 * Security rules are defined to ensure that users can only see the Purchase Requisition of that Operating Units in which they are allowed access to.
 
-When the user creates a purchase order (PO) from the purchase requisition the
-operating unit is copied to the PO.
+* Ensures that Operating Unit in Purchase Requisition and the Warehouse of picking type belongs to the same Operating Unit.
 
-Will set by default the Picking type which haves Operating Unit in Warehouse that of the User.
+* When the user creates a Purchase Order (PO) from the purchase requisition the operating unit is copied to that PO.
 
-Warehouse of picking type
+* Sets default Picking type having Operating Unit (OU) in Warehouse that of the User.
 
 
 Installation

--- a/purchase_requisition_operating_unit/README.rst
+++ b/purchase_requisition_operating_unit/README.rst
@@ -17,16 +17,6 @@ This module introduces the following features:
 * Sets default Picking type whoes Operating Unit (OU) in Warehouse matches to that of the User.
 
 
-Installation
-============
-
-No specific installation requirements.
-
-Configuration
-=============
-
-No configuration is required. 
-
 Usage
 =====
 

--- a/purchase_requisition_operating_unit/README.rst
+++ b/purchase_requisition_operating_unit/README.rst
@@ -1,0 +1,75 @@
+.. image:: https://img.shields.io/badge/license-LGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/lgpl.html
+   :alt: License: LGPL-3
+
+=========================================
+Purchase Requisition with Operating Units
+=========================================
+
+This module introduces the following features:
+
+* Adds Operating Unit (OU) to the account moves and its lines created by the payslip, based on the Operating Unit (OU) defined in the Employee's Contract.
+
+* Security rules are defined to ensure that users can only see the Purchase Requisition of that Operating Units in which they are allowed access to.
+
+When the user creates a purchase order (PO) from the purchase requisition the
+operating unit is copied to the PO.
+
+Will set by default the Picking type which haves Operating Unit in Warehouse that of the User.
+
+Warehouse of picking type
+
+
+Installation
+============
+
+No specific installation requirements.
+
+Configuration
+=============
+
+No configuration is required. 
+
+Usage
+=====
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/9.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/operating-unit/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smashing it by providing a detailed and welcomed feedback.
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Eficent Business and IT Consulting Services S.L. <contact@eficent.com>
+* Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: https://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit https://odoo-community.org.

--- a/purchase_requisition_operating_unit/README.rst
+++ b/purchase_requisition_operating_unit/README.rst
@@ -22,7 +22,7 @@ Usage
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot
-   :target: https://runbot.odoo-community.org/runbot/213/9.0
+   :target: https://runbot.odoo-community.org/runbot/213/10.0
 
 Bug Tracker
 ===========

--- a/purchase_requisition_operating_unit/__init__.py
+++ b/purchase_requisition_operating_unit/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import model

--- a/purchase_requisition_operating_unit/__init__.py
+++ b/purchase_requisition_operating_unit/__init__.py
@@ -5,3 +5,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from . import model
+from . import tests

--- a/purchase_requisition_operating_unit/__init__.py
+++ b/purchase_requisition_operating_unit/__init__.py
@@ -1,8 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
-# Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-
 from . import model
 from . import tests

--- a/purchase_requisition_operating_unit/__init__.py
+++ b/purchase_requisition_operating_unit/__init__.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
-# © 2016 Serpent Consulting Services Pvt. Ltd.
+# Copyright 2016-17 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016-17 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
 from . import model
 from . import tests

--- a/purchase_requisition_operating_unit/__manifest__.py
+++ b/purchase_requisition_operating_unit/__manifest__.py
@@ -1,11 +1,13 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
-# © 2016 Serpent Consulting Services Pvt. Ltd.
+# Copyright 2016-17 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016-17 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 {
     "name": "Operating Unit in Purchase Requisitions",
-    "version": "9.0.1.0.0",
+    "version": "10.0.1.0.0",
     "author": "Eficent Business and IT Consulting Services S.L., "
               "Serpent Consulting Services Pvt. Ltd.,"
               "Odoo Community Association (OCA)",

--- a/purchase_requisition_operating_unit/__openerp__.py
+++ b/purchase_requisition_operating_unit/__openerp__.py
@@ -1,0 +1,83 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+{
+    "name": "Operating Unit in Purchase Requisitions",
+    "version": "9.0.1.0.0",
+    "author": "Eficent",
+    "website": "http://www.eficent.com",
+    "category": "Purchase Management",
+    "depends": ["purchase_requisition",
+                "purchase_operating_unit"],
+    "description": """
+Operating Unit in Purchase Requisitions
+=======================================
+This module was written to extend the Purchase Requsition capabilities of Odoo.
+
+This module introduces the operating unit to the purchase requisition.
+
+Security rules are defined to ensure that users can only display the
+Purchase Requisitions in which they are allowed access to.
+
+Installation
+============
+
+No additional installation instructions are required.
+
+
+Configuration
+=============
+
+This module does not require any additional configuration.
+
+Usage
+=====
+
+At the time when a user creates a new purchase requisition the system
+proposes the user's default operating unit.
+
+The operating unit is a required field.
+
+When the user creates a purchase order (PO) from the purchase requisition the
+operating unit is copied to the PO.
+
+
+Known issues / Roadmap
+======================
+
+No issue has been identified.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Jordi Ballester <jordi.ballester@eficent.com>
+
+Maintainer
+----------
+
+.. image:: http://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.
+
+To contribute to this module, please visit http://odoo-community.org.
+
+
+    """,
+    "data": [
+        "view/purchase_requisition.xml",
+        "security/purchase_security.xml",
+    ],
+    'installable': True,
+}

--- a/purchase_requisition_operating_unit/__openerp__.py
+++ b/purchase_requisition_operating_unit/__openerp__.py
@@ -7,74 +7,14 @@
 {
     "name": "Operating Unit in Purchase Requisitions",
     "version": "9.0.1.0.0",
-    "author": "Eficent",
+    "author": "Eficent Business and IT Consulting Services S.L., "
+              "Serpent Consulting Services Pvt. Ltd.,"
+              "Odoo Community Association (OCA)",
+    "license": "LGPL-3",
     "website": "http://www.eficent.com",
     "category": "Purchase Management",
     "depends": ["purchase_requisition",
                 "purchase_operating_unit"],
-    "description": """
-Operating Unit in Purchase Requisitions
-=======================================
-This module was written to extend the Purchase Requsition capabilities of Odoo.
-
-This module introduces the operating unit to the purchase requisition.
-
-Security rules are defined to ensure that users can only display the
-Purchase Requisitions in which they are allowed access to.
-
-Installation
-============
-
-No additional installation instructions are required.
-
-
-Configuration
-=============
-
-This module does not require any additional configuration.
-
-Usage
-=====
-
-At the time when a user creates a new purchase requisition the system
-proposes the user's default operating unit.
-
-The operating unit is a required field.
-
-When the user creates a purchase order (PO) from the purchase requisition the
-operating unit is copied to the PO.
-
-
-Known issues / Roadmap
-======================
-
-No issue has been identified.
-
-Credits
-=======
-
-Contributors
-------------
-
-* Jordi Ballester <jordi.ballester@eficent.com>
-
-Maintainer
-----------
-
-.. image:: http://odoo-community.org/logo.png
-   :alt: Odoo Community Association
-   :target: http://odoo-community.org
-
-This module is maintained by the OCA.
-
-OCA, or the Odoo Community Association, is a nonprofit organization whose
-mission is to support the collaborative development of Odoo features and
-promote its widespread use.
-
-To contribute to this module, please visit http://odoo-community.org.
-
-
-    """,
     "data": [
         "view/purchase_requisition.xml",
         "security/purchase_security.xml",

--- a/purchase_requisition_operating_unit/__openerp__.py
+++ b/purchase_requisition_operating_unit/__openerp__.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
-# Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 {

--- a/purchase_requisition_operating_unit/model/__init__.py
+++ b/purchase_requisition_operating_unit/model/__init__.py
@@ -1,7 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
-# Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-
 from . import purchase_requisition

--- a/purchase_requisition_operating_unit/model/__init__.py
+++ b/purchase_requisition_operating_unit/model/__init__.py
@@ -1,0 +1,7 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from . import purchase_requisition

--- a/purchase_requisition_operating_unit/model/__init__.py
+++ b/purchase_requisition_operating_unit/model/__init__.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
-# © 2016 Serpent Consulting Services Pvt. Ltd.
+# Copyright 2016-17 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016-17 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
 from . import purchase_requisition

--- a/purchase_requisition_operating_unit/model/purchase_requisition.py
+++ b/purchase_requisition_operating_unit/model/purchase_requisition.py
@@ -4,7 +4,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import fields, models, api
 from openerp.tools.translate import _
-from openerp.exceptions import Warning
+from openerp.exceptions import Warning as UserError
 
 
 class PurchaseRequisition(models.Model):
@@ -15,8 +15,8 @@ class PurchaseRequisition(models.Model):
     def _get_picking_in(self):
         res = super(PurchaseRequisition, self)._get_picking_in()
         type_obj = self.env['stock.picking.type']
-        operating_unit = self.env['res.users'].operating_unit_default_get(
-                self._uid)
+        operating_unit = self.env['res.users'].\
+            operating_unit_default_get(self._uid)
         types = type_obj.search([('code', '=', 'incoming'),
                                  ('warehouse_id.operating_unit_id', '=',
                                   operating_unit.id)])
@@ -42,9 +42,9 @@ class PurchaseRequisition(models.Model):
     def _check_company_operating_unit(self):
         for rec in self:
             if rec.company_id and rec.operating_unit_id and \
-                            rec.company_id != rec.operating_unit_id.company_id:
-                raise Warning(_('The Company in the Purchase Requisition and '
-                                'in the Operating Unit must be the same.'))
+                    rec.company_id != rec.operating_unit_id.company_id:
+                raise UserError(_('The Company in the Purchase Requisition and'
+                                  ' in the Operating Unit must be the same.'))
 
     @api.multi
     @api.constrains('operating_unit_id', 'picking_type_id')
@@ -53,13 +53,13 @@ class PurchaseRequisition(models.Model):
             picking_type = rec.picking_type_id
             if picking_type:
                 if picking_type.warehouse_id and\
-                        picking_type.warehouse_id.operating_unit_id\
-                        and rec.operating_unit_id and\
-                        picking_type.warehouse_id.operating_unit_id != \
-                                rec.operating_unit_id:
-                    raise Warning(_('Configuration error!\nThe Operating Unit in\
-                    Purchase Requisition and the Warehouse of picking type\
-                    must belong to the same Operating Unit.'))
+                    picking_type.warehouse_id.operating_unit_id\
+                    and rec.operating_unit_id and\
+                    picking_type.warehouse_id.operating_unit_id !=\
+                        rec.operating_unit_id:
+                    raise UserError(_('Configuration error!\nThe Operating \
+                    Unit in Purchase Requisition and the Warehouse of picking \
+                    type must belong to the same Operating Unit.'))
 
     @api.onchange('operating_unit_id')
     def _onchange_operating_unit_id(self):
@@ -71,9 +71,9 @@ class PurchaseRequisition(models.Model):
             if types:
                 self.picking_type_id = types[:1]
             else:
-                raise Warning(_("No Warehouse found with the "
-                                "Operating Unit indicated in the "
-                                "Purchase Requisition!"))
+                raise UserError(_("No Warehouse found with the "
+                                  "Operating Unit indicated in the "
+                                  "Purchase Requisition!"))
 
     @api.model
     def _prepare_purchase_order(self, requisition, supplier):

--- a/purchase_requisition_operating_unit/model/purchase_requisition.py
+++ b/purchase_requisition_operating_unit/model/purchase_requisition.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
-# Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp import fields, models, api
 from openerp.tools.translate import _
@@ -38,27 +37,29 @@ class PurchaseRequisition(models.Model):
                                       required=True,
                                       default=_get_picking_in)
 
-    @api.one
+    @api.multi
     @api.constrains('operating_unit_id', 'company_id')
     def _check_company_operating_unit(self):
-        if self.company_id and self.operating_unit_id and \
-                self.company_id != self.operating_unit_id.company_id:
-            raise Warning(_('The Company in the Purchase Requisition and in '
-                            'the Operating Unit must be the same.'))
+        for rec in self:
+            if rec.company_id and rec.operating_unit_id and \
+                            rec.company_id != rec.operating_unit_id.company_id:
+                raise Warning(_('The Company in the Purchase Requisition and '
+                                'in the Operating Unit must be the same.'))
 
-    @api.one
+    @api.multi
     @api.constrains('operating_unit_id', 'picking_type_id')
     def _check_warehouse_operating_unit(self):
-        picking_type = self.picking_type_id
-        if picking_type:
-            if picking_type.warehouse_id and\
-                    picking_type.warehouse_id.operating_unit_id\
-                    and self.operating_unit_id and\
-                    picking_type.warehouse_id.operating_unit_id !=\
-                    self.operating_unit_id:
-                raise Warning(_('Configuration error!\nThe Operating Unit in\
-                Purchase Requisition and the Warehouse of picking type\
-                must belong to the same Operating Unit.'))
+        for rec in self:
+            picking_type = rec.picking_type_id
+            if picking_type:
+                if picking_type.warehouse_id and\
+                        picking_type.warehouse_id.operating_unit_id\
+                        and rec.operating_unit_id and\
+                        picking_type.warehouse_id.operating_unit_id != \
+                                rec.operating_unit_id:
+                    raise Warning(_('Configuration error!\nThe Operating Unit in\
+                    Purchase Requisition and the Warehouse of picking type\
+                    must belong to the same Operating Unit.'))
 
     @api.onchange('operating_unit_id')
     def _onchange_operating_unit_id(self):

--- a/purchase_requisition_operating_unit/model/purchase_requisition.py
+++ b/purchase_requisition_operating_unit/model/purchase_requisition.py
@@ -1,0 +1,91 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openerp import fields, models, api
+from openerp.tools.translate import _
+from openerp.exceptions import Warning
+
+
+class PurchaseRequisition(models.Model):
+
+    _inherit = 'purchase.requisition'
+
+    @api.model
+    def _get_picking_in(self):
+        res = super(PurchaseRequisition, self)._get_picking_in()
+        type_obj = self.env['stock.picking.type']
+        operating_unit = self.env['res.users'].operating_unit_default_get(
+                self._uid)
+        types = type_obj.search([('code', '=', 'incoming'),
+                                 ('warehouse_id.operating_unit_id', '=',
+                                  operating_unit.id)])
+        if types:
+            res = types[:1].id
+        return res
+
+    operating_unit_id = fields.Many2one('operating.unit', 'Operating Unit',
+                                        readonly=True,
+                                        states={'draft': [('readonly',
+                                                           False)]},
+                                        default=lambda self:
+                                        self.env['res.users'].
+                                        operating_unit_default_get(self._uid))
+
+    picking_type_id = fields.Many2one('stock.picking.type', 'Picking Type',
+                                      domain=[('code', '=', 'incoming')],
+                                      required=True,
+                                      default=_get_picking_in)
+
+    @api.one
+    @api.constrains('operating_unit_id', 'company_id')
+    def _check_company_operating_unit(self):
+        if self.company_id and self.operating_unit_id and \
+                self.company_id != self.operating_unit_id.company_id:
+            raise Warning(_('The Company in the Purchase Requisition and in '
+                            'the Operating Unit must be the same.'))
+
+    @api.one
+    @api.constrains('operating_unit_id', 'picking_type_id')
+    def _check_warehouse_operating_unit(self):
+        picking_type = self.picking_type_id
+        if picking_type:
+            if picking_type.warehouse_id and\
+                    picking_type.warehouse_id.operating_unit_id\
+                    and self.operating_unit_id and\
+                    picking_type.warehouse_id.operating_unit_id !=\
+                    self.operating_unit_id:
+                raise Warning(_('Configuration error!\nThe Operating Unit in\
+                Purchase Requisition and the Warehouse of picking type\
+                must belong to the same Operating Unit.'))
+
+    @api.onchange('operating_unit_id')
+    def _onchange_operating_unit_id(self):
+        type_obj = self.env['stock.picking.type']
+        if self.operating_unit_id:
+            types = type_obj.search([('code', '=', 'incoming'),
+                                     ('warehouse_id.operating_unit_id', '=',
+                                      self.operating_unit_id.id)])
+            if types:
+                self.picking_type_id = types[:1]
+            else:
+                raise Warning(_("No Warehouse found with the "
+                                "Operating Unit indicated in the "
+                                "Purchase Requisition!"))
+
+    @api.model
+    def _prepare_purchase_order(self, requisition, supplier):
+        res = super(PurchaseRequisition, self).\
+            _prepare_purchase_order(requisition, supplier)
+        res.update({'operating_unit_id': requisition.operating_unit_id.id})
+        return res
+
+
+class PurchaseRequisitionLine(models.Model):
+    _inherit = 'purchase.requisition.line'
+
+    operating_unit_id = fields.Many2one('operating.unit', 'Operating Unit',
+                                        related='requisition_id.'
+                                        'operating_unit_id',
+                                        readonly=True, store=True)

--- a/purchase_requisition_operating_unit/security/purchase_security.xml
+++ b/purchase_requisition_operating_unit/security/purchase_security.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
+<!-- Copyright 2015 Eficent Business and IT Consulting Services S.L.
+     Serpent Consulting Services Pvt. Ltd.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
 <openerp>
     <data noupdate="0">
 

--- a/purchase_requisition_operating_unit/security/purchase_security.xml
+++ b/purchase_requisition_operating_unit/security/purchase_security.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data noupdate="0">
+
+        <record id="ir_rule_purchase_requisition_allowed_operating_units"
+                model="ir.rule">
+            <field name="model_id" ref="purchase_requisition.model_purchase_requisition"/>
+            <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+            <field name="name">PR's from allowed operating units</field>
+            <field name="global" eval="True"/>
+            <field eval="0" name="perm_unlink"/>
+            <field eval="0" name="perm_write"/>
+            <field eval="1" name="perm_read"/>
+            <field eval="0" name="perm_create"/>
+        </record>
+
+        <record id="ir_rule_purchase_requisition_line_allowed_operating_units"
+                model="ir.rule">
+            <field name="model_id" ref="purchase_requisition.model_purchase_requisition_line"/>
+            <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+            <field name="name">PR lines from allowed operating units</field>
+            <field name="global" eval="True"/>
+            <field eval="0" name="perm_unlink"/>
+            <field eval="0" name="perm_write"/>
+            <field eval="1" name="perm_read"/>
+            <field eval="0" name="perm_create"/>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_requisition_operating_unit/security/purchase_security.xml
+++ b/purchase_requisition_operating_unit/security/purchase_security.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Copyright 2015 Eficent Business and IT Consulting Services S.L.
-     Serpent Consulting Services Pvt. Ltd.
+<!-- Copyright 2016-17 Eficent Business and IT Consulting Services S.L.
+     Copyright 2016-17 Serpent Consulting Services Pvt. Ltd.
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
-<openerp>
+<odoo>
     <data noupdate="0">
 
         <record id="ir_rule_purchase_requisition_allowed_operating_units"
@@ -30,4 +30,4 @@
         </record>
 
     </data>
-</openerp>
+</odoo>

--- a/purchase_requisition_operating_unit/tests/__init__.py
+++ b/purchase_requisition_operating_unit/tests/__init__.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
-# Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
-# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)..
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import test_purchase_requisition_operating_unit

--- a/purchase_requisition_operating_unit/tests/__init__.py
+++ b/purchase_requisition_operating_unit/tests/__init__.py
@@ -1,0 +1,6 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html)..
+from . import test_purchase_requisition_operating_unit

--- a/purchase_requisition_operating_unit/tests/__init__.py
+++ b/purchase_requisition_operating_unit/tests/__init__.py
@@ -1,5 +1,8 @@
 # -*- coding: utf-8 -*-
-# © 2016 Eficent Business and IT Consulting Services S.L.
-# © 2016 Serpent Consulting Services Pvt. Ltd.
+# Copyright 2016-17 Eficent Business and IT Consulting Services S.L.
+#   (http://www.eficent.com)
+# Copyright 2016-17 Serpent Consulting Services Pvt. Ltd.
+#   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
 from . import test_purchase_requisition_operating_unit

--- a/purchase_requisition_operating_unit/tests/test_purchase_requisition_operating_unit.py
+++ b/purchase_requisition_operating_unit/tests/test_purchase_requisition_operating_unit.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+# © 2015 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from openerp.tests import common
+from openerp.exceptions import ValidationError
+
+
+class TestPurchaseRequisitionOperatingUnit(common.TransactionCase):
+
+    # Test Cases:
+    # - Create Purchase Requisition
+    #   - Change operating_unit_id will change picking_type_id correctly
+    #   - User can't use picking_type_id not belong to same operating_unit_id
+    # - When create PO, the OU and picking_type_id will be pass correctly
+
+    def setUp(self):
+        super(TestPurchaseRequisitionOperatingUnit, self).setUp()
+        self.pr_model = self.env['purchase.requisition']
+        self.pr_line_model = self.env['purchase.requisition.line']
+        self.po_model = self.env['purchase.order']
+        # company
+        self.company = self.env.ref('base.main_company')
+        self.grp_acc_manager = self.env.ref('account.group_account_manager')
+        # Main Operating Unit
+        self.ou1 = self.env.ref('operating_unit.main_operating_unit')
+        # B2B Operating Unit
+        self.b2b = self.env.ref('operating_unit.b2b_operating_unit')
+        # B2C Operating Unit
+        self.b2c = self.env.ref('operating_unit.b2c_operating_unit')
+        # Partner
+        self.partner1 = self.env.ref('base.res_partner_1')
+        # Products
+        self.product1 = self.env.ref('product.product_product_7')
+        self.product2 = self.env.ref('product.product_product_9')
+
+    def _create_pr(self):
+        line_products = [(self.product1, 1000),
+                         (self.product2, 500), ]
+        lines = []
+        for product, qty in line_products:
+            line_values = {
+                'product_id': product.id,
+                'product_qty': qty,
+            }
+            lines.append((0, 0, line_values))
+        pr_vals = {
+            'exclusive': 'exclusive',
+            'operating_unit_id': self.ou1.id,
+            'line_ids': lines,
+        }
+        # Create PR
+        self.pr = self.pr_model.sudo().create(pr_vals)
+
+    def test_create_purchase_requisition(self):
+        self._create_pr()
+        # Change OU, result in warning
+        with self.assertRaises(ValidationError):
+            self.pr.operating_unit_id = self.b2c
+        # on_change OU
+        pr_mock = self.pr_model.new()
+        pr_mock.operating_unit_id = self.b2c
+        pr_mock._onchange_operating_unit_id()
+        picktype = pr_mock.picking_type_id  # on change result
+        self.assertEqual(self.b2c, picktype.warehouse_id.operating_unit_id,
+                         'Purchase Requisition and the Warehouse of picking '
+                         'type does not belong to same Operating Unit.')
+        # Now OU and Picking Type should be in line as b2c
+        self.pr.picking_type_id = picktype
+        # Confirm Call
+        self.pr.sudo().signal_workflow('sent_suppliers')
+        self.assertEqual(self.pr.state, 'in_progress',
+                         'State not changed to Confirmed')
+        # Create PO
+        pr_po = self.pr.make_purchase_order(self.partner1.id)
+        po_id = pr_po.get(self.pr.id)
+        self.po = self.po_model.browse(po_id)
+        self.assertEqual(self.po.operating_unit_id, self.pr.operating_unit_id,
+                         'Operating Unit is not correctly passed to PO')
+        self.assertEqual(self.po.picking_type_id, self.pr.picking_type_id,
+                         'Picking Type is not correctly passed to PO')

--- a/purchase_requisition_operating_unit/tests/test_purchase_requisition_operating_unit.py
+++ b/purchase_requisition_operating_unit/tests/test_purchase_requisition_operating_unit.py
@@ -1,7 +1,6 @@
 # -*- coding: utf-8 -*-
-# © 2015 Eficent Business and IT Consulting Services S.L. -
-# Jordi Ballester Alomar
-# © 2015 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# © 2016 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from openerp.tests import common
 from openerp.exceptions import ValidationError

--- a/purchase_requisition_operating_unit/view/purchase_requisition.xml
+++ b/purchase_requisition_operating_unit/view/purchase_requisition.xml
@@ -1,4 +1,7 @@
 <?xml version="1.0"?>
+<!-- Copyright 2015 Eficent Business and IT Consulting Services S.L.
+     Serpent Consulting Services Pvt. Ltd.
+     License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
 <openerp>
     <data>
 
@@ -19,7 +22,7 @@
             <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form" />
             <field name="arch" type="xml">
                 <field name="company_id" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" options="{'no_create': True}"/>
                     <field name="picking_type_id"></field>
                 </field>
                 <xpath expr="//field[@name='line_ids']" position="attributes">

--- a/purchase_requisition_operating_unit/view/purchase_requisition.xml
+++ b/purchase_requisition_operating_unit/view/purchase_requisition.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0"?>
+<openerp>
+    <data>
+
+        <record id="view_purchase_requisition_tree" model="ir.ui.view">
+            <field name="name">purchase.requisition.tree</field>
+            <field name="model">purchase.requisition</field>
+            <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_tree" />
+            <field name="arch" type="xml">
+                <field name="company_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+        <record id="view_purchase_requisition_form" model="ir.ui.view">
+            <field name="name">purchase.requisition.form</field>
+            <field name="model">purchase.requisition</field>
+            <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form" />
+            <field name="arch" type="xml">
+                <field name="company_id" position="after">
+                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                    <field name="picking_type_id"></field>
+                </field>
+                <xpath expr="//field[@name='line_ids']" position="attributes">
+                    <attribute name="context">{'operating_unit_id': operating_unit_id}</attribute>
+                </xpath>
+            </field>
+        </record>
+
+        <record id="view_purchase_requisition_filter" model="ir.ui.view">
+            <field name="name">purchase.requisition.list.select</field>
+            <field name="model">purchase.requisition</field>
+            <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_filter" />
+            <field name="arch" type="xml">
+                <xpath expr="//filter[1]" position="after">
+                  <filter string="Operating Unit" context="{'group_by':'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit"/>
+                </xpath>
+                <field name="exclusive" position="after">
+                  <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
+                </field>
+            </field>
+        </record>
+
+    </data>
+</openerp>

--- a/purchase_requisition_operating_unit/view/purchase_requisition.xml
+++ b/purchase_requisition_operating_unit/view/purchase_requisition.xml
@@ -1,49 +1,47 @@
 <?xml version="1.0"?>
-<!-- Copyright 2015 Eficent Business and IT Consulting Services S.L.
-     Serpent Consulting Services Pvt. Ltd.
+<!-- Copyright 2016-17 Eficent Business and IT Consulting Services S.L.
+     Copyright 2016-17 Serpent Consulting Services Pvt. Ltd.
      License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0) -->
-<openerp>
-    <data>
+<odoo>
 
-        <record id="view_purchase_requisition_tree" model="ir.ui.view">
-            <field name="name">purchase.requisition.tree</field>
-            <field name="model">purchase.requisition</field>
-            <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_tree" />
-            <field name="arch" type="xml">
-                <field name="company_id" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="view_purchase_requisition_tree" model="ir.ui.view">
+        <field name="name">purchase.requisition.tree</field>
+        <field name="model">purchase.requisition</field>
+        <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_tree" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-        <record id="view_purchase_requisition_form" model="ir.ui.view">
-            <field name="name">purchase.requisition.form</field>
-            <field name="model">purchase.requisition</field>
-            <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form" />
-            <field name="arch" type="xml">
-                <field name="company_id" position="after">
-                    <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" options="{'no_create': True}"/>
-                    <field name="picking_type_id"></field>
-                </field>
-                <xpath expr="//field[@name='line_ids']" position="attributes">
-                    <attribute name="context">{'operating_unit_id': operating_unit_id}</attribute>
-                </xpath>
+    <record id="view_purchase_requisition_form" model="ir.ui.view">
+        <field name="name">purchase.requisition.form</field>
+        <field name="model">purchase.requisition</field>
+        <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_form" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" options="{'no_create': True}"/>
+                <field name="picking_type_id"></field>
             </field>
-        </record>
+            <xpath expr="//field[@name='line_ids']" position="attributes">
+                <attribute name="context">{'operating_unit_id': operating_unit_id}</attribute>
+            </xpath>
+        </field>
+    </record>
 
-        <record id="view_purchase_requisition_filter" model="ir.ui.view">
-            <field name="name">purchase.requisition.list.select</field>
-            <field name="model">purchase.requisition</field>
-            <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_filter" />
-            <field name="arch" type="xml">
-                <xpath expr="//filter[1]" position="after">
-                  <filter string="Operating Unit" context="{'group_by':'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit"/>
-                </xpath>
-                <field name="exclusive" position="after">
-                  <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
-                </field>
+    <record id="view_purchase_requisition_filter" model="ir.ui.view">
+        <field name="name">purchase.requisition.list.select</field>
+        <field name="model">purchase.requisition</field>
+        <field name="inherit_id" ref="purchase_requisition.view_purchase_requisition_filter" />
+        <field name="arch" type="xml">
+            <xpath expr="//filter[1]" position="after">
+              <filter string="Operating Unit" context="{'group_by':'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit"/>
+            </xpath>
+            <field name="type_id" position="after">
+              <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"/>
             </field>
-        </record>
+        </field>
+    </record>
 
-    </data>
-</openerp>
+</odoo>


### PR DESCRIPTION
Purchase Requisition with Operating Units
=========================================

This module introduces the following features:

* Security rules are defined to ensure that users can only see the Purchase Requisition of that Operating Units in which they are allowed access to.

* Ensures that Purchase Requisition and the Warehouse in picking type belongs to the same Operating Unit (OU) .

* When the user creates a Purchase Order (PO) from the purchase requisition the operating unit is passed to that PO.

* Sets default Picking type whoes Operating Unit (OU) in Warehouse matches to that of the User.