### PR TITLE
[FIX][10.0]stock_operating_unit

### DIFF
--- a/stock_operating_unit/__manifest__.py
+++ b/stock_operating_unit/__manifest__.py
@@ -7,7 +7,7 @@
     "name": "Stock with Operating Units",
     "summary": "An operating unit (OU) is an organizational entity part of a "
                "company",
-    "version": "10.0.1.0.0",
+    "version": "10.0.1.0.1",
     "category": "Generic Modules/Sales & Purchases",
     "author": "Eficent, "
               "Serpent Consulting Services Pvt. Ltd., "

--- a/stock_operating_unit/model/stock.py
+++ b/stock_operating_unit/model/stock.py
@@ -111,8 +111,7 @@ class StockPicking(models.Model):
     _inherit = 'stock.picking'
 
     operating_unit_id = fields.Many2one('operating.unit',
-                                        'Requesting Operating Unit',
-                                        readonly=1)
+                                        'Requesting Operating Unit')
 
     @api.onchange('picking_type_id', 'partner_id')
     def onchange_picking_type(self):


### PR DESCRIPTION
**Requesting operating unit in manual picking never been set**

Current behavior: When selecting the picking type in the picking the requesting operating unit is automatically set. When saving, the picking the requesting operating unit is missing.

Expected behavior: The requesting operating unit remains there.

Solution: Set the requesting operating unit as editable. Currently, there's a constraint that prevents for inconsistencies so there's no risk of inconsistency data.
