### PR TITLE
[10.0][FIX] Purchase Operating Unit

### DIFF
--- a/purchase_operating_unit/__manifest__.py
+++ b/purchase_operating_unit/__manifest__.py
@@ -8,7 +8,7 @@
     "name": "Operating Unit in Purchase Orders",
     "summary": "An operating unit (OU) is an organizational entity part of a "
                "company",
-    "version": "10.0.1.1.0",
+    "version": "10.0.1.1.1",
     "author": "Eficent, "
               "Serpent Consulting Services Pvt. Ltd.,"
               "Odoo Community Association (OCA)",

--- a/purchase_operating_unit/models/procurement.py
+++ b/purchase_operating_unit/models/procurement.py
@@ -15,8 +15,9 @@ class ProcurementOrder(models.Model):
     def _check_purchase_order_operating_unit(self):
         for proc in self:
             if proc.location_id.usage not in ('supplier', 'customer') and \
-                (proc.purchase_line_id.order_id.operating_unit_id !=
-                    proc.location_id.operating_unit_id):
+                proc.purchase_line_id.order_id and \
+                    (proc.purchase_line_id.order_id.operating_unit_id !=
+                        proc.location_id.operating_unit_id):
                 raise ValidationError(
                     _('Configuration error. The Quotation / Purchase Order '
                       'and the Procurement Order must belong to the same '

--- a/purchase_operating_unit/models/procurement.py
+++ b/purchase_operating_unit/models/procurement.py
@@ -11,19 +11,17 @@ class ProcurementOrder(models.Model):
     _inherit = 'procurement.order'
 
     @api.multi
-    @api.constrains('purchase_line_id')
+    @api.constrains('purchase_line_id', 'location_id')
     def _check_purchase_order_operating_unit(self):
         for proc in self:
-            purchase_ou = proc.purchase_line_id.order_id.operating_unit_id
-            location_ou = proc.location_id.operating_unit_id
-            usage = proc.location_id.usage
-            if usage not in ('supplier', 'customer'):
-                if purchase_ou != location_ou:
-                    raise ValidationError(
-                        _('Configuration error. The Quotation / Purchase Order'
-                          ' and the Procurement Order must belong to the same '
-                          'Operating Unit.')
-                        )
+            if proc.location_id.usage not in ('supplier', 'customer') and \
+                (proc.purchase_line_id.order_id.operating_unit_id !=
+                    proc.location_id.operating_unit_id):
+                raise ValidationError(
+                    _('Configuration error. The Quotation / Purchase Order '
+                      'and the Procurement Order must belong to the same '
+                      'Operating Unit.')
+                    )
 
     @api.multi
     def _prepare_purchase_order(self, partner):

--- a/purchase_operating_unit/models/procurement.py
+++ b/purchase_operating_unit/models/procurement.py
@@ -14,10 +14,12 @@ class ProcurementOrder(models.Model):
     @api.constrains('purchase_line_id', 'location_id')
     def _check_purchase_order_operating_unit(self):
         for proc in self:
-            if proc.location_id.usage not in ('supplier', 'customer') and \
-                proc.purchase_line_id.order_id and \
-                    (proc.purchase_line_id.order_id.operating_unit_id !=
-                        proc.location_id.operating_unit_id):
+            if not proc.purchase_line_id:
+                continue
+            ou = proc.location_id.operating_unit_id
+            order_ou = proc.purchase_line_id.operating_unit_id
+            if (ou != order_ou and
+                    proc.location_id.usage not in ('supplier', 'customer')):
                 raise ValidationError(
                     _('Configuration error. The Quotation / Purchase Order '
                       'and the Procurement Order must belong to the same '

--- a/purchase_operating_unit/models/purchase.py
+++ b/purchase_operating_unit/models/purchase.py
@@ -113,7 +113,7 @@ class PurchaseOrderLine(models.Model):
     operating_unit_id = fields.Many2one(related='order_id.operating_unit_id',
                                         string='Operating Unit', readonly=True)
 
-    @api.constrains('operating_unit_id', 'invoice_lines')
+    @api.constrains('order_id.operating_unit_id', 'invoice_lines')
     def _check_invoice_ou(self):
         for line in self:
             for inv_line in line.invoice_lines:


### PR DESCRIPTION
Current behavior: Created procurement in customers. Created PO to satisfy this procurement. Constraint raising: `The PO OU is not the same OU as the procurement location`

Expected behavior: As the PO is supposed to deliver directly to customers, the constraint should not raise.

Solution: Avoid raising a constraint when the procurement location is not in the company.

Update: The constraint should check the condition only when there's a PO actually.