### PR TITLE
[11.0][IMP] Add Event Operating Unit module

### DIFF
--- a/event_operating_unit/README.rst
+++ b/event_operating_unit/README.rst
@@ -7,7 +7,7 @@ Event Operating Units
 =====================
 
 This module introduces the operating unit on the Event and adds a related field to the auxillary Types of an event (registration, tracks, sponsors).
-Also it adds default filters to the list views.
+Also it is shipped with the proper record rules.
 
 .. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
    :alt: Try me on Runbot

--- a/event_operating_unit/README.rst
+++ b/event_operating_unit/README.rst
@@ -1,0 +1,49 @@
+.. image:: https://img.shields.io/badge/license-LGPLv3-blue.svg
+   :target: https://www.gnu.org/licenses/lgpl.html
+   :alt: License: LGPL-3
+
+=====================
+Event Operating Units
+=====================
+
+This module introduces the operating unit on the Event and adds a related field to the auxillary Types of an event (registration, tracks, sponsors).
+Also it adds default filters to the list views.
+
+.. image:: https://odoo-community.org/website/image/ir.attachment/5784_f2813bd/datas
+   :alt: Try me on Runbot
+   :target: https://runbot.odoo-community.org/runbot/213/11.0
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/OCA/operating-unit/issues>`_. In case of trouble, please
+check there if your issue has already been reported. If you spotted it first,
+help us smash it by providing a detailed and welcomed feedback.
+
+
+Credits
+=======
+
+Images
+------
+
+* Odoo Community Association: `Icon <https://github.com/OCA/maintainer-tools/blob/master/template/module/static/description/icon.svg>`_.
+
+Contributors
+------------
+
+* Timon Tschanz <timon.tschanz@camptocamp.com>
+
+Maintainer
+----------
+
+.. image:: https://odoo-community.org/logo.png
+   :alt: Odoo Community Association
+   :target: http://odoo-community.org
+
+This module is maintained by the OCA.
+
+OCA, or the Odoo Community Association, is a nonprofit organization whose
+mission is to support the collaborative development of Odoo features and
+promote its widespread use.

--- a/event_operating_unit/__init__.py
+++ b/event_operating_unit/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import models

--- a/event_operating_unit/__init__.py
+++ b/event_operating_unit/__init__.py
@@ -1,3 +1,3 @@
 # Copyright 2018 Camptocamp SA
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from . import models

--- a/event_operating_unit/__manifest__.py
+++ b/event_operating_unit/__manifest__.py
@@ -1,0 +1,22 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+{
+    'name': 'Event Operating Unit',
+    'version': '11.0.1.0.0',
+    'category': 'others',
+    'license': 'AGPL-3',
+    'author': 'camptocamp, Odoo Community Association (OCA)',
+    'website': 'https://github.com/OCA/operating_unit',
+    'depends': [
+        'event',
+        'operating_unit',
+        'website_event_track',
+    ],
+    'data': [
+        'views/event_views.xml',
+        'views/event_track_views.xml',
+        'views/event_registration_views.xml',
+        'views/event_sponsor_views.xml',
+    ],
+    'installable': True,
+}

--- a/event_operating_unit/__manifest__.py
+++ b/event_operating_unit/__manifest__.py
@@ -13,11 +13,11 @@
         'website_event_track',
     ],
     'data': [
+        'security/event_operating_security.xml',
         'views/event_views.xml',
         'views/event_track_views.xml',
         'views/event_registration_views.xml',
         'views/event_sponsor_views.xml',
-        'security/event_operating_security.xml',
     ],
     'installable': True,
 }

--- a/event_operating_unit/__manifest__.py
+++ b/event_operating_unit/__manifest__.py
@@ -17,6 +17,7 @@
         'views/event_track_views.xml',
         'views/event_registration_views.xml',
         'views/event_sponsor_views.xml',
+        'security/event_operating_security.xml',
     ],
     'installable': True,
 }

--- a/event_operating_unit/__manifest__.py
+++ b/event_operating_unit/__manifest__.py
@@ -1,10 +1,10 @@
 # Copyright 2018 Camptocamp SA
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 {
     'name': 'Event Operating Unit',
     'version': '11.0.1.0.0',
     'category': 'others',
-    'license': 'AGPL-3',
+    'license': 'LGPL-3',
     'author': 'camptocamp, Odoo Community Association (OCA)',
     'website': 'https://github.com/OCA/operating_unit',
     'depends': [

--- a/event_operating_unit/i18n/fr.po
+++ b/event_operating_unit/i18n/fr.po
@@ -1,0 +1,49 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+# 	* event_operating_unit
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0+e\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-05-16 12:55+0000\n"
+"PO-Revision-Date: 2018-05-16 14:56+0200\n"
+"Last-Translator: Didier Donzé <didier.donze@camptocamp.com>\n"
+"Language-Team: French\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n > 1);\n"
+"Language: fr\n"
+
+#. module: event_operating_unit
+#: model:ir.model,name:event_operating_unit.model_event_registration
+msgid "Attendee"
+msgstr "Participant"
+
+#. module: event_operating_unit
+#: model:ir.model,name:event_operating_unit.model_event_event
+msgid "Event"
+msgstr "Événement"
+
+#. module: event_operating_unit
+#: model:ir.model,name:event_operating_unit.model_event_sponsor
+msgid "Event Sponsor"
+msgstr "Sponsor de l'événement"
+
+#. module: event_operating_unit
+#: model:ir.model,name:event_operating_unit.model_event_track
+msgid "Event Track"
+msgstr "Session de l'événement"
+
+#. module: event_operating_unit
+#: model:ir.model.fields,field_description:event_operating_unit.field_event_event_operating_unit_id
+#: model:ir.model.fields,field_description:event_operating_unit.field_event_registration_operating_unit_id
+#: model:ir.model.fields,field_description:event_operating_unit.field_event_sponsor_operating_unit_id
+#: model:ir.model.fields,field_description:event_operating_unit.field_event_track_operating_unit_id
+#: model:ir.ui.view,arch_db:event_operating_unit.view_event_search
+#: model:ir.ui.view,arch_db:event_operating_unit.view_event_sponsor_search_inherit_ou
+#: model:ir.ui.view,arch_db:event_operating_unit.view_event_track_search
+#: model:ir.ui.view,arch_db:event_operating_unit.view_registration_search_inherit_ou
+msgid "Operating Unit"
+msgstr "Département"

--- a/event_operating_unit/models/__init__.py
+++ b/event_operating_unit/models/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import event

--- a/event_operating_unit/models/__init__.py
+++ b/event_operating_unit/models/__init__.py
@@ -1,3 +1,3 @@
 # Copyright 2018 Camptocamp SA
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from . import event

--- a/event_operating_unit/models/event.py
+++ b/event_operating_unit/models/event.py
@@ -1,11 +1,11 @@
 # Copyright 2018 Camptocamp SA
 # License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
-from odoo import models, fields, api
+from odoo import api, fields, models
 
 
 class Event(models.Model):
 
-    _inherit = "event.event"
+    _inherit = 'event.event'
 
     @api.model
     def _default_operating_unit(self):
@@ -17,42 +17,16 @@ class Event(models.Model):
         default=lambda self: self._default_operating_unit()
     )
 
-    operating_unit_user_ids = fields.One2many(
-        string='operating_unit Users',
-        comodel_name='res.users',
-        compute='_compute_operating_unit_user_ids',
-        search='_search_operating_unit_user_ids'
-    )
 
-    @api.multi
-    def _compute_operating_unit_user_ids(self):
-        for record in self:
-            result = self.env['res.users'].search(
-                [('operating_unit_ids', 'in', self.operating_unit_id.ids)]
-            )
-            record.operating_unit_user_ids = result.ids
-
-    def _search_operating_unit_user_ids(self, operator, value):
-        result = self.env['res.users'].search(
-            [('id', 'in', value)]
-        )
-        return [('operating_unit_id', 'in', result.operating_unit_ids.ids)]
-
-
-class EventRegistraion(models.Model):
+class EventRegistration(models.Model):
 
     _inherit = 'event.registration'
 
     operating_unit_id = fields.Many2one(
         string='Operating Unit',
         related='event_id.operating_unit_id',
-        readonly=True
-    )
-
-    operating_unit_user_ids = fields.One2many(
-        string='Operating Unit user ids',
-        related='event_id.operating_unit_user_ids',
-        readonly=True
+        readonly=True,
+        store=True
     )
 
 
@@ -63,13 +37,8 @@ class EventSponsor(models.Model):
     operating_unit_id = fields.Many2one(
         string='Operating Unit',
         related='event_id.operating_unit_id',
-        readonly=True
-    )
-
-    operating_unit_user_ids = fields.One2many(
-        string='Operating Unit user ids',
-        related='event_id.operating_unit_user_ids',
-        readonly=True
+        readonly=True,
+        store=True
     )
 
 
@@ -80,11 +49,6 @@ class EventTrack(models.Model):
     operating_unit_id = fields.Many2one(
         string='Operating Unit',
         related='event_id.operating_unit_id',
-        readonly=True
-        )
-
-    operating_unit_user_ids = fields.One2many(
-        string='Operating Unit user ids',
-        related='event_id.operating_unit_user_ids',
-        readonly=True
-        )
+        readonly=True,
+        store=True
+    )

--- a/event_operating_unit/models/event.py
+++ b/event_operating_unit/models/event.py
@@ -1,0 +1,90 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo import models, fields, api
+
+
+class Event(models.Model):
+
+    _inherit = "event.event"
+
+    @api.model
+    def _default_operating_unit(self):
+        return self.env.user.default_operating_unit_id
+
+    operating_unit_id = fields.Many2one(
+        comodel_name='operating.unit',
+        string='Operating Unit',
+        default=lambda self: self._default_operating_unit()
+    )
+
+    operating_unit_user_ids = fields.One2many(
+        string='operating_unit Users',
+        comodel_name='res.users',
+        compute='_compute_operating_unit_user_ids',
+        search='_search_operating_unit_user_ids'
+    )
+
+    @api.multi
+    def _compute_operating_unit_user_ids(self):
+        for record in self:
+            result = self.env['res.users'].search(
+                [('operating_unit_ids', 'in', self.operating_unit_id.ids)]
+            )
+            record.operating_unit_user_ids = result.ids
+
+    def _search_operating_unit_user_ids(self, operator, value):
+        result = self.env['res.users'].search(
+            [('id', 'in', value)]
+        )
+        return [('operating_unit_id', 'in', result.operating_unit_ids.ids)]
+
+
+class EventRegistraion(models.Model):
+
+    _inherit = 'event.registration'
+
+    operating_unit_id = fields.Many2one(
+        string='Operating Unit',
+        related='event_id.operating_unit_id',
+        readonly=True
+    )
+
+    operating_unit_user_ids = fields.One2many(
+        string='Operating Unit user ids',
+        related='event_id.operating_unit_user_ids',
+        readonly=True
+    )
+
+
+class EventSponsor(models.Model):
+
+    _inherit = 'event.sponsor'
+
+    operating_unit_id = fields.Many2one(
+        string='Operating Unit',
+        related='event_id.operating_unit_id',
+        readonly=True
+    )
+
+    operating_unit_user_ids = fields.One2many(
+        string='Operating Unit user ids',
+        related='event_id.operating_unit_user_ids',
+        readonly=True
+    )
+
+
+class EventTrack(models.Model):
+
+    _inherit = 'event.track'
+
+    operating_unit_id = fields.Many2one(
+        string='Operating Unit',
+        related='event_id.operating_unit_id',
+        readonly=True
+        )
+
+    operating_unit_user_ids = fields.One2many(
+        string='Operating Unit user ids',
+        related='event_id.operating_unit_user_ids',
+        readonly=True
+        )

--- a/event_operating_unit/models/event.py
+++ b/event_operating_unit/models/event.py
@@ -1,5 +1,5 @@
 # Copyright 2018 Camptocamp SA
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from odoo import api, fields, models
 
 

--- a/event_operating_unit/security/event_operating_security.xml
+++ b/event_operating_unit/security/event_operating_security.xml
@@ -7,7 +7,7 @@
         <field name="model_id" ref="event.model_event_event"/>
         <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
         <field name="name">Events from allowed operating units</field>
-        <field name="global" eval="True"/>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field eval="0" name="perm_unlink"/>
         <field eval="0" name="perm_write"/>
         <field eval="1" name="perm_read"/>
@@ -18,7 +18,7 @@
         <field name="model_id" ref="website_event_track.model_event_sponsor"/>
         <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
         <field name="name">Event Sponsor from allowed operating units</field>
-        <field name="global" eval="True"/>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field eval="0" name="perm_unlink"/>
         <field eval="0" name="perm_write"/>
         <field eval="1" name="perm_read"/>
@@ -29,7 +29,7 @@
         <field name="model_id" ref="website_event_track.model_event_track"/>
         <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in',user.operating_unit_ids.ids)]</field>
         <field name="name">Event tracks from allowed operating units</field>
-        <field name="global" eval="True"/>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field eval="0" name="perm_unlink"/>
         <field eval="0" name="perm_write"/>
         <field eval="1" name="perm_read"/>
@@ -40,7 +40,7 @@
         <field name="model_id" ref="event.model_event_registration"/>
         <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
         <field name="name">registrations from allowed operating units</field>
-        <field name="global" eval="True"/>
+        <field name="groups" eval="[(4, ref('base.group_user'))]"/>
         <field eval="0" name="perm_unlink"/>
         <field eval="0" name="perm_write"/>
         <field eval="1" name="perm_read"/>

--- a/event_operating_unit/security/event_operating_security.xml
+++ b/event_operating_unit/security/event_operating_security.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo noupdate="0">
+
+    <!--It might be a good idea to restrict write and unlink as well. But were keeping to only read for consitency.-->
+    <record id="ir_rule_event_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id" ref="event.model_event_event"/>
+        <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
+        <field name="name">Events from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+    <record id="ir_rule_event_sponsor_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id" ref="website_event_track.model_event_sponsor"/>
+        <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
+        <field name="name">Event Sponsor from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+    <record id="ir_rule_event_track_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id" ref="website_event_track.model_event_track"/>
+        <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in',user.operating_unit_ids.ids)]</field>
+        <field name="name">Event tracks from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+    <record id="ir_rule_event_registration_allowed_operating_units"
+            model="ir.rule">
+        <field name="model_id" ref="event.model_event_registration"/>
+        <field name="domain_force">['|', ('operating_unit_id','=', False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
+        <field name="name">registrations from allowed operating units</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
+</odoo>

--- a/event_operating_unit/security/event_operating_security.xml
+++ b/event_operating_unit/security/event_operating_security.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<odoo noupdate="0">
+<odoo noupdate="1">
 
     <!--It might be a good idea to restrict write and unlink as well. But were keeping to only read for consitency.-->
     <record id="ir_rule_event_allowed_operating_units"

--- a/event_operating_unit/tests/__init__.py
+++ b/event_operating_unit/tests/__init__.py
@@ -1,0 +1,3 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from . import test_operating_unit_user_id

--- a/event_operating_unit/tests/__init__.py
+++ b/event_operating_unit/tests/__init__.py
@@ -1,3 +1,3 @@
 # Copyright 2018 Camptocamp SA
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from . import test_operating_unit_user_id

--- a/event_operating_unit/tests/test_operating_unit_user_id.py
+++ b/event_operating_unit/tests/test_operating_unit_user_id.py
@@ -1,0 +1,97 @@
+# Copyright 2018 Camptocamp SA
+# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from odoo.tests.common import SavepointCase
+
+
+class TestOperatiingUnitUserId(SavepointCase):
+
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+
+        cls.ou1 = cls.env.ref('operating_unit.b2c_operating_unit')
+        cls.ou2 = cls.env.ref('operating_unit.b2b_operating_unit')
+
+        cls.user1 = cls.env['res.users'].with_context(
+            no_reset_password=True,
+            tracking_disable=True).create({
+                'name': 'User 1',
+                'login': 'user1',
+                'operating_unit_ids': [(4, cls.ou1.id)]
+            })
+
+        cls.user2 = cls.env['res.users'].with_context(
+            no_reset_password=True,
+            tracking_disable=True).create({
+                'name': 'User 2',
+                'login': 'user2',
+                'operating_unit_ids': [(4, cls.ou2.id)]
+            })
+
+        cls.user3 = cls.env['res.users'].with_context(
+            no_reset_password=True,
+            tracking_disable=True).create({
+                'name': 'User 3',
+                'login': 'user3',
+                'operating_unit_ids': [(4, cls.ou1.id), (4, cls.ou2.id)]
+            })
+
+        cls.event1 = cls.env['event.event'].create({
+            'name': 'Testevent',
+            'operating_unit_id': cls.ou1.id,
+            'date_begin': '2018-03-01 10:00:00',
+            'date_end': '2018-03-01 11:00:00'
+        })
+
+        cls.event2 = cls.env['event.event'].create({
+            'name': 'Testevent',
+            'operating_unit_id': cls.ou2.id,
+            'date_begin': '2018-03-01 10:00:00',
+            'date_end': '2018-03-01 11:00:00'
+        })
+
+    def test_compute(self):
+        users = self.event1.operating_unit_user_ids
+        # The demo user is in all ous so we have 3 instead of 2
+        self.assertEqual(len(users), 3)
+        # We should find user1 which is only in ou 1 and user3
+        # which is in both.
+        self.assertIn(self.user1, users)
+        self.assertIn(self.user3, users)
+        # But user2 doesn't belong to our orgunit
+        self.assertNotIn(self.user2, users)
+
+        users = self.event2.operating_unit_user_ids
+        # The demo user is in all ous so we have 3 instead of 2
+        self.assertEqual(len(users), 3)
+
+        # In ou2 we have user2 & user3
+        self.assertIn(self.user2, users)
+        self.assertIn(self.user3, users)
+        # But we don't have user1
+        self.assertNotIn(self.user1, users)
+
+    def test_search(self):
+        events_user1 = self.env['event.event'].search(
+            [('operating_unit_user_ids', 'in', self.user1.ids)]
+        )
+
+        events_user2 = self.env['event.event'].search(
+            [('operating_unit_user_ids', 'in', self.user2.ids)]
+        )
+        events_user3 = self.env['event.event'].search(
+            [('operating_unit_user_ids', 'in', self.user3.ids)]
+        )
+
+        # we have one event in each ou.
+        # user1 & user2 are assigned to one ou each
+        self.assertEqual(len(events_user1), 1)
+        self.assertEqual(len(events_user2), 1)
+        # user3 is assigned to both
+        self.assertEqual(len(events_user3), 2)
+
+        # make sure we got the right one.
+        self.assertEqual(events_user1[0], self.event1)
+        self.assertEqual(events_user2[0], self.event2)
+        self.assertIn(self.event1, events_user3)
+        self.assertIn(self.event2, events_user3)

--- a/event_operating_unit/tests/test_operating_unit_user_id.py
+++ b/event_operating_unit/tests/test_operating_unit_user_id.py
@@ -1,5 +1,5 @@
 # Copyright 2018 Camptocamp SA
-# License AGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl.html).
 from odoo.tests.common import SavepointCase
 
 

--- a/event_operating_unit/views/event_registration_views.xml
+++ b/event_operating_unit/views/event_registration_views.xml
@@ -5,9 +5,9 @@
         <field name="model">event.registration</field>
         <field name="inherit_id" ref="event.view_event_registration_tree" />
         <field name="arch" type="xml">
-            <xpath expr="field[@name='state']" position="after">
+            <field name="state" position="after">
                 <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
-            </xpath>
+            </field>
         </field>
     </record>
 

--- a/event_operating_unit/views/event_registration_views.xml
+++ b/event_operating_unit/views/event_registration_views.xml
@@ -18,15 +18,10 @@
         <field name="arch" type="xml">
             <search>
                 <field name="operating_unit_id" string="Operating Unit" groups="operating_unit.group_multi_operating_unit" />
-                <filter name="my_ou" string="My Operating Unit" domain="[('operating_unit_user_ids', 'in', [uid])]" />
             </search>
-            <xpath expr="//group[1]">
-                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}"/>
+            <xpath expr="//filter[@context=&quot;{'group_by':'event_id'}&quot;]" position="after">
+                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit" />
             </xpath>
         </field>
-    </record>
-
-    <record model="ir.actions.act_window" id="event.action_registration">
-        <field name="context">{"search_default_my_ou":1}</field>
     </record>
 </odoo>

--- a/event_operating_unit/views/event_registration_views.xml
+++ b/event_operating_unit/views/event_registration_views.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_event_registration_tree_inherit_ou">
+        <field name="name">event.registration.tree</field>
+        <field name="model">event.registration</field>
+        <field name="inherit_id" ref="event.view_event_registration_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="field[@name='state']" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_registration_search_inherit_ou">
+        <field name="name">event.registration.search</field>
+        <field name="model">event.registration</field>
+        <field name="inherit_id" ref="event.view_registration_search" />
+        <field name="arch" type="xml">
+            <search>
+                <field name="operating_unit_id" string="Operating Unit" groups="operating_unit.group_multi_operating_unit" />
+                <filter name="my_ou" string="My Operating Unit" domain="[('operating_unit_user_ids', 'in', [uid])]" />
+            </search>
+            <xpath expr="//group[1]">
+                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}"/>
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="event.action_registration">
+        <field name="context">{"search_default_my_ou":1}</field>
+    </record>
+</odoo>

--- a/event_operating_unit/views/event_sponsor_views.xml
+++ b/event_operating_unit/views/event_sponsor_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_event_sponsor_tree_inherit_ou">
+        <field name="name">event.sponsor.tree</field>
+        <field name="model">event.sponsor</field>
+        <field name="inherit_id" ref="website_event_track.view_event_sponsor_tree" />
+        <field name="arch" type="xml">
+            <tree>
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_event_sponsor_search_inherit_ou">
+        <field name="name">event.sponsor.search</field>
+        <field name="model">event.sponsor</field>
+        <field name="inherit_id" ref="website_event_track.view_event_sponsor_search" />
+        <field name="arch" type="xml">
+            <search>
+                <field name="operating_unit_id" string="Operating Unit" groups="operating_unit.group_multi_operating_unit" />
+                <filter name="my_ou" string="My Operating Unit" domain="[('operating_unit_user_ids', 'in', [uid])]" />
+            </search>
+        </field>
+    </record>
+</odoo>

--- a/event_operating_unit/views/event_sponsor_views.xml
+++ b/event_operating_unit/views/event_sponsor_views.xml
@@ -5,9 +5,9 @@
         <field name="model">event.sponsor</field>
         <field name="inherit_id" ref="website_event_track.view_event_sponsor_tree" />
         <field name="arch" type="xml">
-            <tree>
+            <field name="sponsor_type_id" position="after">
                 <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
-            </tree>
+            </field>
         </field>
     </record>
 
@@ -18,7 +18,6 @@
         <field name="arch" type="xml">
             <search>
                 <field name="operating_unit_id" string="Operating Unit" groups="operating_unit.group_multi_operating_unit" />
-                <filter name="my_ou" string="My Operating Unit" domain="[('operating_unit_user_ids', 'in', [uid])]" />
             </search>
         </field>
     </record>

--- a/event_operating_unit/views/event_track_views.xml
+++ b/event_operating_unit/views/event_track_views.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_event_track_tree_inherit_ou">
+        <field name="name">event.track.tree</field>
+        <field name="model">event.track</field>
+        <field name="inherit_id" ref="website_event_track.view_event_track_tree" />            
+        <field name="arch" type="xml">
+            <tree>
+                <field name="name"/>
+                <field name="active" invisible="1"/>
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_event_track_search">
+        <field name="name">event.track.search</field>
+        <field name="model">event.track</field>
+        <field name="inherit_id" ref="website_event_track.view_event_track_search" />
+        <field name="arch" type="xml">
+            <search>
+                <field name="operating_unit_id" string="Operating Unit" groups="operating_unit.group_multi_operating_unit" />
+                <filter name="my_ou" string="My Operating Unit" domain="[('operating_unit_user_ids', 'in', [uid])]" />
+            </search>
+            <xpath expr="//group[1]">
+                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}"/>
+
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="website_event_track.action_event_track">
+        <field name="context">{"search_default_my_ou":1,}</field>
+    </record>
+</odoo>

--- a/event_operating_unit/views/event_track_views.xml
+++ b/event_operating_unit/views/event_track_views.xml
@@ -5,11 +5,9 @@
         <field name="model">event.track</field>
         <field name="inherit_id" ref="website_event_track.view_event_track_tree" />            
         <field name="arch" type="xml">
-            <tree>
-                <field name="name"/>
-                <field name="active" invisible="1"/>
+            <field name="event_id" position="after">
                 <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
-            </tree>
+            </field>
         </field>
     </record>
 
@@ -20,16 +18,11 @@
         <field name="arch" type="xml">
             <search>
                 <field name="operating_unit_id" string="Operating Unit" groups="operating_unit.group_multi_operating_unit" />
-                <filter name="my_ou" string="My Operating Unit" domain="[('operating_unit_user_ids', 'in', [uid])]" />
             </search>
-            <xpath expr="//group[1]">
-                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}"/>
+            <xpath expr="//filter[@context=&quot;{'group_by':'event_id'}&quot;]" position="after">
+                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit" />
 
             </xpath>
         </field>
-    </record>
-
-    <record model="ir.actions.act_window" id="website_event_track.action_event_track">
-        <field name="context">{"search_default_my_ou":1,}</field>
     </record>
 </odoo>

--- a/event_operating_unit/views/event_views.xml
+++ b/event_operating_unit/views/event_views.xml
@@ -16,9 +16,9 @@
         <field name="model">event.event</field>
         <field name="inherit_id" ref="event.view_event_tree" />
         <field name="arch" type="xml">
-            <tree>
+            <field name="state" position="after">
                 <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
-            </tree>
+            </field>
         </field>
     </record>
 
@@ -29,22 +29,11 @@
         <field name="arch" type="xml">
             <search>
                 <field name="operating_unit_id" string="Operating Unit" groups="operating_unit.group_multi_operating_unit" />
-                   <filter name="my_ou" string="My Operating Unit" domain="[('operating_unit_user_ids', 'in', [uid])]" />
             </search>
-            <xpath expr="//group[1]">
-                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}"/>
+            <xpath expr="//filter[@context=&quot;{'group_by':'date_begin'}&quot;]" position="after">
+                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}" groups="operating_unit.group_multi_operating_unit" />
 
             </xpath>
         </field>
     </record>
-
-    <record model="ir.actions.act_window" id="event.action_event_view">
-        <field name="context">
-            {
-                "search_default_upcoming":1,
-                "search_default_my_ou":1,
-            }
-        </field>
-   </record>
-
 </odoo>

--- a/event_operating_unit/views/event_views.xml
+++ b/event_operating_unit/views/event_views.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<odoo>
+    <record model="ir.ui.view" id="view_event_form_inherit_ou">
+        <field name="name">event.event.form</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_form" />
+        <field name="arch" type="xml">
+            <field name="user_id" position="after">
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
+            </field>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_event_tree_inherit_ou">
+        <field name="name">event.event.tree</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_tree" />
+        <field name="arch" type="xml">
+            <tree>
+                <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit" />
+            </tree>
+        </field>
+    </record>
+
+    <record model="ir.ui.view" id="view_event_search">
+        <field name="name">event.event.search</field>
+        <field name="model">event.event</field>
+        <field name="inherit_id" ref="event.view_event_search" />
+        <field name="arch" type="xml">
+            <search>
+                <field name="operating_unit_id" string="Operating Unit" groups="operating_unit.group_multi_operating_unit" />
+                   <filter name="my_ou" string="My Operating Unit" domain="[('operating_unit_user_ids', 'in', [uid])]" />
+            </search>
+            <xpath expr="//group[1]">
+                <filter string="Operating Unit" context="{'group_by': 'operating_unit_id'}"/>
+
+            </xpath>
+        </field>
+    </record>
+
+    <record model="ir.actions.act_window" id="event.action_event_view">
+        <field name="context">
+            {
+                "search_default_upcoming":1,
+                "search_default_my_ou":1,
+            }
+        </field>
+   </record>
+
+</odoo>


### PR DESCRIPTION
This PR adds operating units to events.
Main points:
    - Adds a operating_unit_id field to the event.
    - Adds a related field to the event operating_unit_id on event.registration, event.track and event.sponsor.
    - Adds record rules to restrict access to the events based on the operating unit.