### PR TITLE
[FIX][10.0] stock_operating_unit 

### DIFF
--- a/stock_operating_unit/model/stock.py
+++ b/stock_operating_unit/model/stock.py
@@ -161,8 +161,9 @@ class StockMove(models.Model):
     )
 
     @api.multi
-    @api.constrains('operating_unit_id', 'location_id', 'picking_id',
-                    'operating_unit_dest_id', 'location_dest_id')
+    @api.constrains('location_id.operating_unit_id', 'picking_id',
+                    'location_id', 'location_dest_id.operating_unit_id',
+                    'location_dest_id')
     def _check_stock_move_operating_unit(self):
         for stock_move in self:
             if not stock_move.operating_unit_id:


### PR DESCRIPTION
The constrains in the method `_check_stock_move_operating_unit` are not correct. As a result we get in the logs: `@constrains parameter' operating_unit_id' is not writeable`