### PR TITLE
[FIX][account_payment]Fix in the internal transfers amount currency

### DIFF
--- a/account_operating_unit/models/account_payment.py
+++ b/account_operating_unit/models/account_payment.py
@@ -47,7 +47,7 @@ class AccountPayment(models.Model):
         if self.currency_id != self.company_id.currency_id:
             dst_liquidity_aml_dict.update({
                 'currency_id': self.currency_id.id,
-                'amount_currency': -self.amount,
+                'amount_currency': self.amount,
             })
 
         dst_liquidity_aml_dict.update({
@@ -62,6 +62,11 @@ class AccountPayment(models.Model):
             'account_id': self.company_id.transfer_account_id.id,
             'journal_id': self.destination_journal_id.id
         }
+        if self.currency_id != self.company_id.currency_id:
+            transfer_debit_aml_dict.update({
+                'currency_id': self.currency_id.id,
+                'amount_currency': -self.amount,
+            })
         transfer_debit_aml_dict.update({
             'operating_unit_id':
                 self.journal_id.operating_unit_id.id or False


### PR DESCRIPTION
**Impacted Versions:**
11.0

**Steps to Reproduce**

- Set USD as company default currency
- Create 2 EUR journals.
- Create a internal transfer between 2 EUR journals.
- Confirm the payment.

**Current behavior**
Odoo raises a Validation Error 
![captura realizada el 2018-04-12 10 38 10](https://user-images.githubusercontent.com/16998467/38688006-a367aee0-3e3d-11e8-8e56-62dfcc9a946c.png)

**Desired Behavior**
Odoo validates the payment.

**Link / Video**
https://www.youtube.com/watch?v=vcFv-7OLGRk&feature=youtu.be

@pedrobaeza @jbeficent @alan196 @moylop260.

Best Regards!
