### PR TITLE
[10.0][FIX]deprecated method

### DIFF
--- a/sale_operating_unit/models/sale.py
+++ b/sale_operating_unit/models/sale.py
@@ -12,7 +12,7 @@ class SaleOrder(models.Model):
 
     @api.model
     def _default_operating_unit(self):
-        team = self.env['crm.team']._get_default_team_id()
+        team = self.sudo().env['crm.team']._get_default_team_id()
         if team.operating_unit_id:
             return team.operating_unit_id
         else:

--- a/sale_stock_operating_unit/models/stock_move.py
+++ b/sale_stock_operating_unit/models/stock_move.py
@@ -13,7 +13,7 @@ class StockMove(models.Model):
         """
         Override to add Operating Units to Picking.
         """
-        values = super(StockMove, self)._prepare_picking_assign()
+        values = super(StockMove, self)._get_new_picking_values()
         sale_line = self.procurement_id and self.procurement_id.sale_line_id
         if sale_line:
             values.update({


### PR DESCRIPTION
UPDATE: keep the method without api as the original one.

ORIGINAL SUMMARY:
If the method def `_get_new_picking_values` in stock_move is inherited in any other module in the way:
```
@api.model
def _get_new_picking_values(self, move):
```
this will crash.
