### PR TITLE
[10.0][FIX]sale_stock_operating_unit

### DIFF
--- a/sale_stock_operating_unit/models/sale_order.py
+++ b/sale_stock_operating_unit/models/sale_order.py
@@ -3,12 +3,27 @@
 # Jordi Ballester Alomar
 # © 2015-17 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from odoo import api, models, _
+from odoo import api, fields, models, _
 from odoo.exceptions import ValidationError
 
 
 class SaleOrder(models.Model):
     _inherit = 'sale.order'
+
+    @api.model
+    def _default_warehouse_id(self):
+        res = super(SaleOrder, self)._default_warehouse_id()
+        team = self._get_default_team()
+        warehouses = self.env['stock.warehouse'].search(
+            [('operating_unit_id', '=', team.sudo().operating_unit_id.id)],
+            limit=1)
+        if warehouses:
+            return warehouses
+        return res
+
+    warehouse_id = fields.Many2one(
+        comodel_name='stock.warehouse',
+        default=_default_warehouse_id)
 
     @api.onchange('team_id')
     def onchange_team_id(self):


### PR DESCRIPTION
When creating a SO from scratch the default warehouse is set to the one defined for the company. This triggers the onchange method in the sales order to set the operating unit according to the warehouse. This is wrong. The default operating unit in the sale order should come from the sales team as the team is going to be assigned to the proper operating unit.