### PR TITLE
[10.0][FIX]stock_operating_unit

### DIFF
--- a/stock_operating_unit/model/stock.py
+++ b/stock_operating_unit/model/stock.py
@@ -70,14 +70,15 @@ class StockLocation(models.Model):
     @api.constrains('operating_unit_id')
     def _check_required_operating_unit(self):
         for rec in self:
-            if rec.usage == 'internal' and not rec.operating_unit_id:
+            if (rec.usage not in ('supplier', 'customer') and not
+                    rec.operating_unit_id):
                 raise UserError(
-                    _('Configuration error\nThe operating unit should be '
+                    _('Configuration error. The operating unit should be '
                       'assigned to internal locations and to non other.')
                 )
-            if rec.usage != 'internal' and rec.operating_unit_id:
+            if rec.usage in ('supplier', 'customer') and rec.operating_unit_id:
                 raise UserError(
-                    _('Configuration error\nThe operating unit should be '
+                    _('Configuration error. The operating unit should be '
                       'assigned to internal locations and to non other.')
                 )
 


### PR DESCRIPTION
Currently we cannot assign an operating unit to a locations that is not 'internal'. IMHO this is wrong. We should add the operating unit to locations type view, production or every usage different than customers/suppliers.