### PR TITLE
[10.0][FIX]field that triggers constraint is not a valid field name

### DIFF
--- a/stock_operating_unit/model/stock.py
+++ b/stock_operating_unit/model/stock.py
@@ -162,8 +162,8 @@ class StockMove(models.Model):
     )
 
     @api.multi
-    @api.constrains('location_id.operating_unit_id', 'picking_id',
-                    'location_id', 'location_dest_id.operating_unit_id',
+    @api.constrains('operating_unit_id', 'picking_id',
+                    'location_id', 'operating_unit_dest_id',
                     'location_dest_id')
     def _check_stock_move_operating_unit(self):
         for stock_move in self:


### PR DESCRIPTION
Current behavior: wrong filed name that will not trigger the constraint.

Expected behavior: The operating unit in the location triggers the constraint. No warning in the logs.