### PR TITLE
[10.0]Fix default operating_unit_id on account.move.line

### DIFF
--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -10,10 +10,7 @@ from odoo.exceptions import UserError
 class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
-    operating_unit_id = fields.Many2one('operating.unit', 'Operating Unit',
-                                        default=lambda self:
-                                        self.env['res.users'].
-                                        operating_unit_default_get(self._uid))
+    operating_unit_id = fields.Many2one('operating.unit', 'Operating Unit')
 
     @api.model
     def create(self, vals):

--- a/account_operating_unit/views/account_move_view.xml
+++ b/account_operating_unit/views/account_move_view.xml
@@ -62,6 +62,9 @@
             <field name="journal_id" position="after">
                 <field name="operating_unit_id"/>
             </field>
+            <field name="line_ids" position="attributes">
+                <attribute name="context">{'line_ids': line_ids, 'journal_id': journal_id, 'default_operating_unit_id': operating_unit_id}</attribute>
+            </field>
             <xpath expr="//field[@name='line_ids']/tree//field[@name='account_id']"
                    position="after">
                 <field name="operating_unit_id"


### PR DESCRIPTION
The default ou in the move line is the one in the journal entry
backport commit from #140 