### PR TITLE
[10.0][FIX]wrong constraint on hr_payroll_account_operating_unit

### DIFF
--- a/hr_payroll_account_operating_unit/models/__init__.py
+++ b/hr_payroll_account_operating_unit/models/__init__.py
@@ -6,3 +6,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from . import hr_payslip
+from . import account_move

--- a/hr_payroll_account_operating_unit/models/account_move.py
+++ b/hr_payroll_account_operating_unit/models/account_move.py
@@ -4,7 +4,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from odoo.tools.translate import _
-from odoo import api, fields, models
+from odoo import api, models
 from odoo.exceptions import ValidationError
 
 

--- a/hr_payroll_account_operating_unit/models/account_move.py
+++ b/hr_payroll_account_operating_unit/models/account_move.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+# Copyright 2016-17 Eficent Business and IT Consulting Services S.L.
+# Copyright 2016-17 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo.tools.translate import _
+from odoo import api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class AccountMove(models.Model):
+
+    _inherit = 'account.move'
+
+    @api.multi
+    @api.constrains('operating_unit_id')
+    def check_payslips_ou(self):
+        for move in self:
+            pay = self.env['hr.payslip'].search(
+                [('move_id', '=', move.id)])
+            if ((pay.operating_unit_id and move.operating_unit_id)
+                    and (pay.operating_unit_id != move.operating_unit_id)):
+                raise ValidationError(_(
+                    'The journal entry and the payslip must have same '
+                    'operating unit'))
+        return True

--- a/hr_payroll_account_operating_unit/models/hr_payslip.py
+++ b/hr_payroll_account_operating_unit/models/hr_payslip.py
@@ -1,38 +1,27 @@
 # -*- coding: utf-8 -*-
 # Copyright 2016-17 Eficent Business and IT Consulting Services S.L.
-#   (http://www.eficent.com)
 # Copyright 2016-17 Serpent Consulting Services Pvt. Ltd.
-#   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
-from odoo.tools.translate import _
-from odoo import api, models
-from odoo.exceptions import UserError
+from odoo import api, fields, models
 
 
 class HrPayslip(models.Model):
 
     _inherit = 'hr.payslip'
 
+    operating_unit_id = fields.Many2one(
+        related='contract_id.operating_unit_id')
+
     @api.multi
     def write(self, vals):
         res = super(HrPayslip, self).write(vals)
         if vals.get('move_id', False):
             for slip in self:
-                if slip.contract_id and slip.contract_id.operating_unit_id:
-                    slip.move_id.write({'operating_unit_id':
-                                        slip.contract_id.operating_unit_id.id})
+                if slip.operating_unit_id:
+                    slip.move_id.operating_unit_id = slip.operating_unit_id.id
                     if slip.move_id.line_ids:
                         slip.move_id.line_ids.\
                             write({'operating_unit_id':
-                                   slip.contract_id.operating_unit_id.id})
+                                   slip.operating_unit_id.id})
         return res
-
-    @api.multi
-    def action_payslip_done(self):
-        OU = self.mapped('contract_id.operating_unit_id').ids
-        if len(OU) > 1:
-            raise UserError(_('Configuration error! '
-                              'The Contracts must refer the same '
-                              'Operating Unit.'))
-        return super(HrPayslip, self).action_payslip_done()

--- a/hr_payroll_account_operating_unit/tests/test_payroll_account_operating_unit.py
+++ b/hr_payroll_account_operating_unit/tests/test_payroll_account_operating_unit.py
@@ -7,7 +7,7 @@
 
 from odoo.addons.hr_contract_operating_unit.tests\
     import test_hr_contract_operating_unit
-from odoo.exceptions import UserError
+from odoo.exceptions import ValidationError
 
 
 class TestPayrollAccountOperatingUnit(test_hr_contract_operating_unit.
@@ -52,10 +52,9 @@ class TestPayrollAccountOperatingUnit(test_hr_contract_operating_unit.
 
     def test_hr_payroll_account_ou(self):
         """Test Payroll Account Operating Unit"""
-        with self.assertRaises(UserError):
-            payslip = self.payslip1 + self.payslip2
-            payslip.action_payslip_done()
-
+        with self.assertRaises(ValidationError):
+            self.payslip1.move_id.write({'operating_unit_id': self.b2c.id})
+        self.payslip1.move_id.operating_unit_id = self.ou1
         # Operating Unit (OU) of contract in Payslip should
         # match with OU of Accounting Entries of that Payslip
         self.assertEqual(self.payslip1.move_id.operating_unit_id,


### PR DESCRIPTION
The constraint was not useful as it will never show an error.
Added related field, it makes sense as the operating unit in the payslip is inherited form the contract.
Also, the operating unit was not propagated correctly.