### PR TITLE
[12.0] [FIX] operating unit security

### DIFF
--- a/operating_unit/README.rst
+++ b/operating_unit/README.rst
@@ -57,6 +57,13 @@ Usage
 This module defines the operating unit entity and the user's security rules.
 Other modules extend the standard Odoo apps with the OU.
 
+Known issues / Roadmap
+======================
+
+The column name of the table operating_unit_users_rel is bad. Change it in v13
+and create the proper migration script.
+
+
 Bug Tracker
 ===========
 

--- a/operating_unit/__manifest__.py
+++ b/operating_unit/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Operating Unit",
     "summary": "An operating unit (OU) is an organizational entity part of a "
                "company",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "author": "Eficent, "
               "Serpent Consulting Services Pvt. Ltd.,"
               "Odoo Community Association (OCA)",

--- a/operating_unit/models/operating_unit.py
+++ b/operating_unit/models/operating_unit.py
@@ -17,6 +17,10 @@ class OperatingUnit(models.Model):
         'res.company', 'Company', required=True, default=lambda self:
         self.env['res.company']._company_default_get('account.account'))
     partner_id = fields.Many2one('res.partner', 'Partner', required=True)
+    user_ids = fields.Many2many(
+        'res.users', 'operating_unit_users_rel', 'poid', 'user_id',
+        'Users Allowed',
+    )
 
     _sql_constraints = [
         ('code_company_uniq', 'unique (code,company_id)',

--- a/operating_unit/readme/ROADMAP.rst
+++ b/operating_unit/readme/ROADMAP.rst
@@ -1,0 +1,3 @@
+
+The column name of the table operating_unit_users_rel is bad. Change it in v13
+and create the proper migration script.

--- a/sales_team_operating_unit/__manifest__.py
+++ b/sales_team_operating_unit/__manifest__.py
@@ -5,7 +5,7 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 {
     "name": "Sales Team Operating Unit",
-    "version": "12.0.1.0.0",
+    "version": "12.0.1.1.0",
     "author": "Eficent, "
               "SerpentCS,"
               "Odoo Community Association (OCA)",

--- a/sales_team_operating_unit/views/crm_team_view.xml
+++ b/sales_team_operating_unit/views/crm_team_view.xml
@@ -22,7 +22,8 @@
         <field name="arch" type="xml">
             <field name="company_id" position="after">
                 <field name="operating_unit_id" groups="operating_unit.group_multi_operating_unit"
-                       domain="[('company_id','=', company_id)]" options="{'no_create': True}"/>
+                       domain="[('company_id','=', company_id),
+                       ('user_ids', 'in', uid)]" options="{'no_create': True}"/>
             </field>
         </field>
     </record>


### PR DESCRIPTION
When creating sales_team (only for creating not editing) the OU manager can see all the operating units even if the manager is not assigned to those. Selecting an OU the manager is not assigned cause an access error when creating the sales team.

Despite the above use case is a clear configuration problem (The OU manager should belong to all OU), we should prevent this error to be raised. IMO the most elegant way to do that is through domains in the fields as it is proposed for sales_team here.

 Notice that this domain is just preventing the manager to select any OU in the sales team. The basic user "Multi operating unit user" currently **cannot see any OU he/she is not assigned to**. This is only for the manager.

Please also notice that the new field in the operating unit will not create any table as it is already created by the field operating_unit_ids in res.users.

@sudhir-erpharbor If you think this is ok to you I will apply the same domain for analytic accounts at #146

@bjeficent  If this is accepted we will apply the same thing to the module account_operating_unit
