### PR TITLE
[10.0] [FIX] mrp_operating_unit

### DIFF
--- a/mrp_operating_unit/models/mrp.py
+++ b/mrp_operating_unit/models/mrp.py
@@ -14,7 +14,7 @@ class MrpProduction(models.Model):
     operating_unit_id = fields.Many2one(
         'operating.unit', 'Operating Unit',
         readonly=True,
-        states={'draft': [('readonly', False)]},
+        states={'confirmed': [('readonly', False)]},
         default=lambda self: self.env['res.users'
                                       ].operating_unit_default_get(self._uid)
     )


### PR DESCRIPTION
mrp_operating unit fix: : Operating unit can't be edited in the view form