### PR TITLE
[10.0][FIX]account_operating_unit

### DIFF
--- a/account_operating_unit/models/invoice.py
+++ b/account_operating_unit/models/invoice.py
@@ -43,6 +43,19 @@ class AccountInvoice(models.Model):
                                         'Operating Unit must be the same.'))
         return True
 
+    @api.multi
+    @api.constrains('operating_unit_id', 'journal_id')
+    def _check_journal_operating_unit(self):
+        for ai in self:
+            if (
+                ai.journal_id.operating_unit_id and
+                ai.operating_unit_id and
+                ai.operating_unit_id != ai.journal_id.operating_unit_id
+            ):
+                raise ValidationError(_('The OU in the Invoice and in '
+                                        'Journal must be the same.'))
+        return True
+
 
 class AccountInvoiceLine(models.Model):
     _inherit = 'account.invoice.line'


### PR DESCRIPTION
Since https://github.com/OCA/operating-unit/commit/0867715a83321271927443a97ee794132c3a6325 we are able to attach any journal to an Operating Unit. Now it it possible to create discrepancies between the OU in the journal and in the invoice:

![image](https://user-images.githubusercontent.com/19620251/51252247-a166b980-199b-11e9-8958-48e46a640a21.png)

This PR fixes that with a constraint:

![image](https://user-images.githubusercontent.com/19620251/51252289-bb080100-199b-11e9-8afa-cc47de480ce1.png)

