### PR TITLE
[12.0][FIX]clear caches when saving so OU rules are updated

### DIFF
--- a/operating_unit/__manifest__.py
+++ b/operating_unit/__manifest__.py
@@ -6,7 +6,7 @@
     "name": "Operating Unit",
     "summary": "An operating unit (OU) is an organizational entity part of a "
                "company",
-    "version": "12.0.1.1.0",
+    "version": "12.0.1.2.0",
     "author": "Eficent, "
               "Serpent Consulting Services Pvt. Ltd.,"
               "Odoo Community Association (OCA)",

--- a/operating_unit/models/operating_unit.py
+++ b/operating_unit/models/operating_unit.py
@@ -14,7 +14,8 @@ class OperatingUnit(models.Model):
     code = fields.Char('Code', required=True)
     active = fields.Boolean('Active', default=True)
     company_id = fields.Many2one(
-        'res.company', 'Company', required=True, default=lambda self:
+        'res.company', 'Company', required=True, readonly=True,
+        default=lambda self:
         self.env['res.company']._company_default_get('account.account'))
     partner_id = fields.Many2one('res.partner', 'Partner', required=True)
     user_ids = fields.Many2many(

--- a/operating_unit/models/operating_unit.py
+++ b/operating_unit/models/operating_unit.py
@@ -48,4 +48,10 @@ class OperatingUnit(models.Model):
     def create(self, values):
         res = super(OperatingUnit, self).create(values)
         res.user_ids += self.env.user
+        self.clear_caches()
         return res
+
+    @api.multi
+    def write(self, vals):
+        self.clear_caches()
+        return super(OperatingUnit, self).write(vals)


### PR DESCRIPTION
Access rules are not updated right away because of the cache. With this change we prevent the system to raise Access Error on newly created OU. The user that creates the OU is auto-assign to the OU but the rule is not updated caused of the bad cache.  This fixes the issue.