### PR TITLE
[10.0] [FIX] purchase_request_procurement_operating_unit

### DIFF
--- a/purchase_request_procurement_operating_unit/README.rst
+++ b/purchase_request_procurement_operating_unit/README.rst
@@ -20,6 +20,13 @@ Usage
    :target: https://runbot.odoo-community.org/runbot/213/10.0
 
 
+Known Issues
+============
+
+Make sure that all Picking Types have assigned a Warehouse, otherwise the OU
+will not be propagated correctly to the Purchase Request.
+
+
 Bug Tracker
 ===========
 

--- a/purchase_request_procurement_operating_unit/model/procurement.py
+++ b/purchase_request_procurement_operating_unit/model/procurement.py
@@ -15,9 +15,9 @@ class Procurement(models.Model):
     @api.multi
     def _prepare_purchase_request(self):
         res = super(Procurement, self)._prepare_purchase_request()
-        if self.location_id.operating_unit_id:
+        if self.warehouse_id.operating_unit_id:
             res.update({
-                'operating_unit_id': self.location_id.operating_unit_id.id
+                'operating_unit_id': self.warehouse_id.operating_unit_id.id
             })
         return res
 


### PR DESCRIPTION
Operating Units are not propagated correctly if the picking type is Dropship. 