### PR TITLE
[10.0] [backport] Sales Team members must have the same Operating Unit

### DIFF
--- a/sales_team_operating_unit/models/crm_team.py
+++ b/sales_team_operating_unit/models/crm_team.py
@@ -5,7 +5,7 @@
 #   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from odoo import api, fields, models, _
-from odoo.exceptions import UserError
+from odoo.exceptions import UserError, ValidationError
 
 
 class CrmTeam(models.Model):
@@ -26,3 +26,13 @@ class CrmTeam(models.Model):
                     team.company_id != team.operating_unit_id.company_id:
                 raise UserError(_('Configuration error!\n\nThe Company in the\
                 Sales Team and in the Operating Unit must be the same.'))
+
+    @api.multi
+    @api.constrains('operating_unit_id', 'member_ids')
+    def _check_member_operating_unit(self):
+        for rec in self.member_ids:
+            if (rec and self.operating_unit_id and
+                    self.operating_unit_id not in rec.operating_unit_ids):
+                    raise ValidationError(_('Configuration error. The user %s '
+                                            'has not assigned the same '
+                                            'Operating unit.' % rec.name))

--- a/sales_team_operating_unit/tests/test_crm_team_operating_unit.py
+++ b/sales_team_operating_unit/tests/test_crm_team_operating_unit.py
@@ -5,6 +5,7 @@
 #   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from odoo.tests import common
+from odoo import exceptions
 
 
 class TestSaleTeamOperatingUnit(common.TransactionCase):
@@ -65,3 +66,13 @@ class TestSaleTeamOperatingUnit(common.TransactionCase):
                     ('operating_unit_id', '=', self.ou1.id)])
         self.assertEqual(team.ids, [], 'User 2 should not have access to '
                          '%s' % self.ou1.name)
+
+    def test_member_operating_unit(self):
+        # User 2 is assigned to B2C Operating Unit and cannot be a member of
+        # a team with the Operating Unit OU1
+        with self.assertRaises(exceptions.ValidationError):
+            self.crm_team_model.sudo().create({
+                'name': 'Test Team',
+                'operating_unit_id': self.ou1.id,
+                'member_ids': [(4, self.user2.id)]
+            })


### PR DESCRIPTION
Backport of ca2b5473e8df5c7708420cb36579196edf5b33f7

New constraint to control that the members of Sales Teams have the same Operating Unit assigned.