### PR TITLE
[10.0][FIX]account_operating_unit not working when reconciling

### DIFF
--- a/account_operating_unit/models/__init__.py
+++ b/account_operating_unit/models/__init__.py
@@ -7,3 +7,4 @@ from . import account_journal
 from . import account_move
 from . import invoice
 from . import account_payment
+from . import account_partial_reconcile

--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -51,6 +51,67 @@ class AccountMoveLine(models.Model):
                                   ' the Move Line and in the Move must be the'
                                   ' same.'))
 
+    @api.multi
+    def _prepare_writeoff_first_line_values(self, values):
+        res = super(
+            AccountMoveLine, self)._prepare_writeoff_first_line_values(values)
+        if not res.get('operating_unit_id', False):
+            res['operating_unit_id'] = self.operating_unit_id.id
+        return res
+
+    @api.multi
+    def _prepare_writeoff_second_line_values(self, values):
+        res = super(
+            AccountMoveLine, self)._prepare_writeoff_second_line_values(values)
+        if not res.get('operating_unit_id', False):
+            res['operating_unit_id'] = self.operating_unit_id.id
+        return res
+
+    @api.multi
+    def _prepare_inter_ou_balancing_partial_reconcile(
+            self, move, ou_id, debit, credit):
+        if not move.company_id.inter_ou_clearing_account_id:
+            raise UserError(_('Error!\nYou need to define an inter-operating\
+                unit clearing account in the company settings'))
+
+        res = {
+            'name': 'OU-Balancing',
+            'move_id': move.id,
+            'journal_id': move.journal_id.id,
+            'date': move.date,
+            'operating_unit_id': ou_id,
+            'account_id': move.company_id.inter_ou_clearing_account_id.id,
+            'debit': debit,
+            'credit': credit
+        }
+        return res
+
+    def _get_move_vals(self):
+        """ Return dict to create the payment move
+        """
+        journal = self.journal_id
+        name = self.name
+        return {
+            'name': name + 'OU Balance',
+            'date': self.date,
+            'ref': self.ref or '/',
+            'company_id': self.company_id.id,
+            'journal_id': journal.id,
+        }
+
+    @api.multi
+    def reconcile(self, writeoff_acc_id=False, writeoff_journal_id=False):
+        res = super(AccountMoveLine, self).reconcile(
+            writeoff_acc_id, writeoff_journal_id)
+        if (not len(self.mapped('operating_unit_id')) == 1 and
+                not self.env.context.get('reversal', False)):
+            partial = self.env['account.partial.reconcile'].search(
+                [('debit_move_id', 'in', self.ids),
+                 ('credit_move_id', 'in', self.ids),
+                 ('bal_move_id', '=', False)])
+            partial.assign_balance_to_partial_reconcile()
+        return res
+
 
 class AccountMove(models.Model):
     _inherit = "account.move"
@@ -99,7 +160,8 @@ class AccountMove(models.Model):
         for move in self:
             if not move.company_id.ou_is_self_balanced:
                 continue
-
+            if self.env.context.get('reconciling'):
+                continue
             # If all move lines point to the same operating unit, there's no
             # need to create a balancing move line
             ou_list_ids = [line.operating_unit_id and

--- a/account_operating_unit/models/account_partial_reconcile.py
+++ b/account_operating_unit/models/account_partial_reconcile.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# © 2016-17 Eficent Business and IT Consulting Services S.L.
+# © 2016 Serpent Consulting Services Pvt. Ltd.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from odoo import api, fields, models
+
+
+class AccountPartialReconcile(models.Model):
+    _inherit = 'account.partial.reconcile'
+
+    bal_move_id = fields.Many2one(
+        'account.move', index=True)
+
+    @api.multi
+    def reverse_bal_entries(self):
+        res = False
+        for rec in self:
+            res = rec.bal_move_id.reverse_moves()
+        return res
+
+    @api.multi
+    def create_ou_balance(self):
+        self.ensure_one()
+        ml_obj = self.env['account.move.line']
+        if not self.credit_move_id.company_id.ou_is_self_balanced\
+                and self.debit_move_id.company_id.ou_is_self_balanced:
+            return False
+
+        # If all move lines point to the same operating unit, there's no
+        # need to create a balancing move line
+        ou_list_ids = [self.credit_move_id.operating_unit_id.id,
+                       self.debit_move_id.operating_unit_id.id]
+        if ou_list_ids.count(ou_list_ids[0]) == len(ou_list_ids):
+            return False
+
+        # Create balancing entries for un-balanced OU's.
+        amls = []
+        move_id = False
+        for ou_id in ou_list_ids:
+            # Create a balancing move line in the operating unit
+            # clearing account
+            if self.credit_move_id.operating_unit_id.id == ou_id:
+                if not move_id:
+                    move_id = self.env['account.move'].create(
+                        self.credit_move_id._get_move_vals())
+                line_data = self.credit_move_id.\
+                    _prepare_inter_ou_balancing_partial_reconcile(
+                        move_id, ou_id, 0.0, self.amount)
+            else:
+                if not move_id:
+                    move_id = self.env['account.move'].create(
+                        self.debit_move_id._get_move_vals())
+                line_data = self.debit_move_id.\
+                    _prepare_inter_ou_balancing_partial_reconcile(
+                        move_id, ou_id, self.amount, 0.0)
+            amls.append(ml_obj.with_context(wip=True).
+                        create(line_data))
+        move_id.with_context(wip=False).\
+            write({'line_ids': [(4, aml.id) for aml in amls]})
+        move_id.with_context(reconciling=True).post()
+        return move_id.id
+
+    @api.multi
+    def assign_balance_to_partial_reconcile(self):
+        if self.env.context.get('reversal', False):
+            return
+        for rec in self:
+            if rec.bal_move_id:
+                rec.reverse_bal_entries()
+            if rec.debit_move_id.operating_unit_id != \
+                    rec.credit_move_id.operating_unit_id:
+                rec.bal_move_id = rec.create_ou_balance()
+
+    @api.multi
+    def unlink(self):
+        for rec in self:
+            if rec.bal_move_id and not self.env.context.get('reversal', False):
+                rec.with_context(reversal=True).reverse_bal_entries()
+        result = super(AccountPartialReconcile, self).unlink()
+        return result

--- a/account_operating_unit/models/account_payment.py
+++ b/account_operating_unit/models/account_payment.py
@@ -2,7 +2,7 @@
 # © 2016-17 Eficent Business and IT Consulting Services S.L.
 # © 2016 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from odoo import api, fields, models, _
+from odoo import api, fields, models
 
 
 class AccountPayment(models.Model):
@@ -19,85 +19,9 @@ class AccountPayment(models.Model):
         'operating.unit', string='Operating Unit',
         compute='_compute_operating_unit_id', readonly=True, store=True)
 
-    def _get_counterpart_move_line_vals(self, invoice=False):
-        res = super(AccountPayment,
-                    self)._get_counterpart_move_line_vals(invoice=invoice)
-        if len(invoice) == 1:
-            res['operating_unit_id'] = invoice.operating_unit_id.id or False
-        else:
-            res['operating_unit_id'] = self.operating_unit_id.id or False
+    def _get_shared_move_line_vals(
+            self, debit, credit, amount_currency, move_id, invoice_id=False):
+        res = super(AccountPayment, self)._get_shared_move_line_vals(
+            debit, credit, amount_currency, move_id, invoice_id)
+        res.update(operating_unit_id=self.operating_unit_id.id)
         return res
-
-    def _get_liquidity_move_line_vals(self, amount):
-        res = super(AccountPayment, self)._get_liquidity_move_line_vals(amount)
-        res['operating_unit_id'] = self.journal_id.operating_unit_id.id \
-            or False
-        return res
-
-    def _get_dst_liquidity_aml_dict_vals(self):
-        dst_liquidity_aml_dict = {
-            'name': _('Transfer from %s') % self.journal_id.name,
-            'account_id':
-                self.destination_journal_id.default_credit_account_id.id,
-            'currency_id': self.destination_journal_id.currency_id.id,
-            'payment_id': self.id,
-            'journal_id': self.destination_journal_id.id,
-        }
-
-        if self.currency_id != self.company_id.currency_id:
-            dst_liquidity_aml_dict.update({
-                'currency_id': self.currency_id.id,
-                'amount_currency': self.amount,
-            })
-
-        dst_liquidity_aml_dict.update({
-            'operating_unit_id':
-                self.destination_journal_id.operating_unit_id.id or False})
-        return dst_liquidity_aml_dict
-
-    def _get_transfer_debit_aml_dict_vals(self):
-        transfer_debit_aml_dict = {
-            'name': self.name,
-            'payment_id': self.id,
-            'account_id': self.company_id.transfer_account_id.id,
-            'journal_id': self.destination_journal_id.id
-        }
-        if self.currency_id != self.company_id.currency_id:
-            transfer_debit_aml_dict.update({
-                'currency_id': self.currency_id.id,
-                'amount_currency': -self.amount,
-            })
-        transfer_debit_aml_dict.update({
-            'operating_unit_id':
-                self.journal_id.operating_unit_id.id or False
-        })
-        return transfer_debit_aml_dict
-
-    def _create_transfer_entry(self, amount):
-        """ We need to override the standard method, until proper hooks are
-        created
-        """
-        aml_obj = self.env['account.move.line'].with_context(
-            check_move_validity=False)
-        debit, credit, amount_currency, dummy = aml_obj.with_context(
-            date=self.payment_date).compute_amount_fields(
-            amount, self.currency_id, self.company_id.currency_id)
-        amount_currency = self.destination_journal_id.currency_id \
-            and self.currency_id.with_context(date=self.payment_date).compute(
-                amount, self.destination_journal_id.currency_id) or 0
-
-        dst_move = self.env['account.move'].create(
-            self._get_move_vals(self.destination_journal_id))
-
-        dst_liquidity_aml_dict = self._get_shared_move_line_vals(
-            debit, credit, amount_currency, dst_move.id)
-        dst_liquidity_aml_dict.update(self._get_dst_liquidity_aml_dict_vals())
-        aml_obj.create(dst_liquidity_aml_dict)
-
-        transfer_debit_aml_dict = self._get_shared_move_line_vals(
-            credit, debit, 0, dst_move.id)
-        transfer_debit_aml_dict.update(
-            self._get_transfer_debit_aml_dict_vals())
-        transfer_debit_aml = aml_obj.create(transfer_debit_aml_dict)
-        dst_move.post()
-        return transfer_debit_aml

--- a/account_operating_unit/models/invoice.py
+++ b/account_operating_unit/models/invoice.py
@@ -56,6 +56,15 @@ class AccountInvoice(models.Model):
                                         'Journal must be the same.'))
         return True
 
+    @api.model
+    def _prepare_refund(
+            self, invoice, date_invoice=None, date=None, description=None,
+            journal_id=None):
+        res = super(AccountInvoice, self)._prepare_refund(
+            invoice, date_invoice, date, description, journal_id)
+        res.update(operating_unit_id=invoice.operating_unit_id.id)
+        return res
+
 
 class AccountInvoiceLine(models.Model):
     _inherit = 'account.invoice.line'


### PR DESCRIPTION
The balancing inter OU entries should be created qhen reconciling entries from different OU. This is not happening in current version. 

Besides, refunds are not assigned to the correct operating unit.

Moreover, write off moves should use the operating unit form the journal

Fixes here should be ported to next versions because it affects normal flow.
