### PR TITLE
[FIX][12.0] sale_stock_operating_unit and purchase_request_operating_unit

### DIFF
--- a/purchase_operating_unit/models/__init__.py
+++ b/purchase_operating_unit/models/__init__.py
@@ -1,3 +1,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import purchase_order
 from . import account_invoice
+from . import stock_rule

--- a/purchase_operating_unit/models/stock_rule.py
+++ b/purchase_operating_unit/models/stock_rule.py
@@ -1,0 +1,25 @@
+# Copyright 2015-19 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# Copyright 2015-19 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    def _prepare_purchase_order(
+        self, product_id, product_qty, product_uom, origin, values, partner
+    ):
+        res = super(StockRule, self)._prepare_purchase_order(
+            product_id, product_qty, product_uom, origin, values, partner
+        )
+        res["operating_unit_id"] = values["warehouse_id"].operating_unit_id.id
+        return res
+
+    def _make_po_get_domain(self, values, partner):
+        res = super(StockRule, self)._make_po_get_domain(values, partner)
+        res += (("operating_unit_id", "=", values.get(
+            "operating_unit_id", False)),)
+        return res

--- a/purchase_request_operating_unit/model/__init__.py
+++ b/purchase_request_operating_unit/model/__init__.py
@@ -1,3 +1,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from . import purchase_request
+from . import stock_rule

--- a/purchase_request_operating_unit/model/stock_rule.py
+++ b/purchase_request_operating_unit/model/stock_rule.py
@@ -1,0 +1,18 @@
+# Copyright 2015-19 Eficent Business and IT Consulting Services S.L. -
+# Jordi Ballester Alomar
+# Copyright 2015-19 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import api, models
+
+
+class StockRule(models.Model):
+    _inherit = 'stock.rule'
+
+    @api.model
+    def _prepare_purchase_request(self, origin, values):
+        res = super(StockRule, self)._prepare_purchase_request(origin, values)
+        res.update({
+            'operating_unit_id': values.get('operating_unit_id', False),
+        })
+        return res

--- a/purchase_request_operating_unit/tests/test_purchase_request_operating_unit.py
+++ b/purchase_request_operating_unit/tests/test_purchase_request_operating_unit.py
@@ -33,7 +33,7 @@ class TestPurchaseRequestOperatingUnit(common.TransactionCase):
             ref('purchase_request.group_purchase_request_manager')
         # Picking Type
         self.b2c_wh = self.env.ref('stock_operating_unit.stock_warehouse_b2c')
-        self.b2c_type_in_id = b2c_wh.in_type_id.id
+        self.b2c_type_in_id = self.b2c_wh.in_type_id.id
         self.picking_type = self.env.ref('stock.picking_type_in')
 
         # Creates Users and Purchase request

--- a/sale_stock_operating_unit/models/__init__.py
+++ b/sale_stock_operating_unit/models/__init__.py
@@ -2,3 +2,4 @@
 from . import sale_order
 from . import stock_move
 from . import stock_warehouse
+from . import stock_rule

--- a/sale_stock_operating_unit/models/__init__.py
+++ b/sale_stock_operating_unit/models/__init__.py
@@ -2,4 +2,3 @@
 from . import sale_order
 from . import stock_move
 from . import stock_warehouse
-from . import stock_rule

--- a/sale_stock_operating_unit/models/sale_order.py
+++ b/sale_stock_operating_unit/models/sale_order.py
@@ -62,3 +62,29 @@ class SaleOrder(models.Model):
                 raise ValidationError(_('Configuration error!\nThe Operating'
                                         'Unit in the Sales Order and in the'
                                         ' Warehouse must be the same.'))
+
+
+class SaleOrderLine(models.Model):
+    _inherit = 'sale.order.line'
+
+    @api.multi
+    def _prepare_procurement_values(self, group_id=False):
+        res = super(SaleOrderLine, self).\
+            _prepare_procurement_values(group_id)
+        res.update({
+            'operating_unit_id':
+                self.order_id.operating_unit_id.id,
+        })
+        return res
+
+    @api.multi
+    def _purchase_service_prepare_line_values(self, purchase_order,
+                                              quantity=False):
+        res = super(SaleOrderLine, self).\
+            _purchase_service_prepare_line_values(
+                purchase_order=purchase_order, quantity=quantity)
+        res.update({
+            'operating_unit_id':
+                self.order_id.operating_unit_id.id,
+        })
+        return res

--- a/sale_stock_operating_unit/models/stock_move.py
+++ b/sale_stock_operating_unit/models/stock_move.py
@@ -19,3 +19,12 @@ class StockMove(models.Model):
         })
 
         return values
+
+    def _prepare_procurement_values(self):
+        res = super(StockMove, self).\
+            _prepare_procurement_values()
+        res.update({
+            'operating_unit_id':
+                self.group_id.sale_id.operating_unit_id.id,
+        })
+        return res

--- a/sale_stock_operating_unit/tests/test_sale_stock_operating_unit.py
+++ b/sale_stock_operating_unit/tests/test_sale_stock_operating_unit.py
@@ -30,9 +30,11 @@ class TestSaleStockOperatingUnit(common.TransactionCase):
         # Price list
         self.pricelist = self.env.ref('product.list0')
         # Products
-        self.product1 = self.env.ref(
-            'product.product_product_7')
-        self.product1.write({'invoice_policy': 'order'})
+        self.product1 = self.env['product.product'].create({
+            'name': 'XX',
+            'type': 'product',
+            'invoice_policy': 'order'
+        })
         # Create user1
         self.user1 = self._create_user('user_1', [self.grp_sale_user,
                                                   self.grp_acc_user],
@@ -51,6 +53,7 @@ class TestSaleStockOperatingUnit(common.TransactionCase):
         # Warehouses
         self.ou1_wh = self.env.ref('stock.warehouse0')
         self.b2c_wh = self.env.ref('stock_operating_unit.stock_warehouse_b2c')
+        self.mto_route = self.b2c_wh.mto_pull_id.route_id
         # Locations
         self.b2c_wh.lot_stock_id.write({'company_id': self.company.id,
                                         'operating_unit_id': self.b2c.id})


### PR DESCRIPTION
Propagate operating unit on MTO scenario. Currently this is not happening.
Todo:
- [x] cover this case with tests

