### PR TITLE
[IMP] purchase_operating_unit: PO-OU's Multi Ware Access

### DIFF
--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -16,11 +16,12 @@ class PurchaseOrder(models.Model):
         operating_unit = self.env['res.users'].operating_unit_default_get(
             self.env.uid
         )
-        types = type_obj.search([('code', '=', 'incoming'),
-                                 ('warehouse_id.operating_unit_id', '=',
-                                  operating_unit.id)])
-        if types:
-            res = types[:1].id
+        if operating_unit:
+            types = type_obj.search([('code', '=', 'incoming'),
+                                    ('warehouse_id.operating_unit_id', '=',
+                                    operating_unit.id)])
+            if types:
+                res = types[:1].id
         return res
 
     READONLY_STATES = {
@@ -63,7 +64,8 @@ class PurchaseOrder(models.Model):
             if not record.picking_type_id:
                 continue
             warehouse = picking_type.warehouse_id
-            if (picking_type.warehouse_id and
+            if (warehouse.operating_unit_id and
+                    picking_type.warehouse_id and
                     picking_type.warehouse_id.operating_unit_id and
                     record.operating_unit_id and
                     warehouse.operating_unit_id != record.operating_unit_id):


### PR DESCRIPTION
This PR allows all PO's to access warehouses that do not have operating_unit_id's set. It also adjusts the default_picking_type method to avoid getting an id from a null value.

#237