### PR TITLE
[FIX] account_operating_unit: Ensure Company Set

### DIFF
--- a/account_operating_unit/views/invoice_view.xml
+++ b/account_operating_unit/views/invoice_view.xml
@@ -47,7 +47,8 @@
                 <attribute name="context">{
                     'type': type,
                     'journal_id': journal_id,
-                    'operating_unit': operating_unit_id}
+                    'operating_unit': operating_unit_id,
+                    'default_company_id': company_id}
                 </attribute>
             </field>
             <field name="invoice_line_ids">


### PR DESCRIPTION
When removing 'editable="bottom"' from the form view, some users have encountered a bug where company_id is not set until after the form is saved. We were able to replicate this behavior on runbot here:
![image](https://user-images.githubusercontent.com/39602586/72461807-f7c42f00-378c-11ea-961e-c4c80310d616.png)

To ensure this doesn't happen, we set the default company_id through the context.