### PR TITLE
[IMP] purchase_operating_unit: Enable Multi Picking/Warehouse on PO's

### DIFF
--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -89,9 +89,10 @@ class PurchaseOrder(models.Model):
     def _onchange_operating_unit_id(self):
         type_obj = self.env['stock.picking.type']
         if self.operating_unit_id:
-            types = type_obj.search([('code', '=', 'incoming'),
-                                     ('warehouse_id.operating_unit_id', '=',
-                                      self.operating_unit_id.id)])
+            types = type_obj.\
+                search([('code', '=', 'incoming'),
+                        ('warehouse_id.operating_unit_id', 'in',
+                        (self.operating_unit_id.id, False))])
             if types:
                 self.picking_type_id = types[:1]
             else:


### PR DESCRIPTION
Do not throw the UserError if we have a warehouse that does not have an operating unit (shared warehouse)