### PR TITLE
[FIX][12.0] Operating Units - Problems with Record Rules

### DIFF
--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -19,7 +19,8 @@
 
     <record id="ir_rule_stock_picking_type_allowed_operating_units" model="ir.rule">
         <field name="model_id" ref="stock.model_stock_picking_type"/>
-        <field name="domain_force">['|',
+        <field name="domain_force">['|', '|',
+            ('warehouse_id','=', False),
             ('warehouse_id.operating_unit_id','=',False),
             ('warehouse_id.operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
         <field name="name">Stock Picking Type from allowed operating units</field>


### PR DESCRIPTION
The record rule "Stock Picking Type from allowed operating units"
(XML ID:
stock_operating_unit.ir_rule_stock_picking_type_allowed_operating_units)
seems not to work properly. If an Operation Type (stock.picking.type)
has no Warehouse set, trying to access it will end up in a security
error due to the record rule mentioned before. How can we solve this?
By extending the rule definition as follows:

```
['|', '|',
    ('warehouse_id','=', False),
    ('warehouse_id.operating_unit_id','=', False),
    ('warehouse_id.operating_unit_id','in',[g.id for g in user.operating_unit_ids])]
```