### PR TITLE
[12.0][REV]company dependent field in operating_unit

### DIFF
--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -30,6 +30,5 @@ class ResUsers(models.Model):
     )
     default_operating_unit_id = fields.Many2one(
         'operating.unit', 'Default Operating Unit',
-        company_dependant=True,
         default=lambda self: self._default_operating_unit()
     )


### PR DESCRIPTION
Fasttracking

https://github.com/OCA/operating-unit/pull/241 was a mistake to merge that. After further investigation, it came out possible incompatibilities between the company of the operating unit and the partner. As long as the solution is not clear, the best thing to revert #241, which it is actually not doing anything.