### PR TITLE
[FIX] stock_operating_unit: Set Picking OU as Location OU

### DIFF
--- a/stock_operating_unit/models/stock_picking.py
+++ b/stock_operating_unit/models/stock_picking.py
@@ -20,7 +20,10 @@ class StockPicking(models.Model):
         if self.picking_type_id:
             unit = self.picking_type_id.warehouse_id.operating_unit_id
         if not unit:
-            unit = self.location_id and self.location_id.operating_unit_id
+            if self.location_id:
+                if self.location_id.operating_unit_id:
+                    unit = self.location_id.operating_unit_id
+
         self.operating_unit_id = unit
 
     @api.multi


### PR DESCRIPTION
Currently this code is storing self.stock_location as unit and users are recieving this error: 
```
File "/opt/odoo/v12/src/link-addons/stock_operating_unit/models/stock_picking.py", line 24, in onchange_operating_unit
    self.operating_unit_id = unit
  File "/opt/odoo/py3env/lib/python3.6/site-packages/odoo-12.0-py3.6.egg/odoo/fields.py", line 1003, in __set__
    value = self.convert_to_cache(value, record)
  File "/opt/odoo/py3env/lib/python3.6/site-packages/odoo-12.0-py3.6.egg/odoo/fields.py", line 2142, in convert_to_cache
    raise ValueError("Wrong value for %s: %r" % (self, value))
ValueError: Wrong value for stock.picking.operating_unit_id: stock.location()
```
This PR fixes this error.