### PR TITLE
[IMP] stock_operating_unit (Update Record Rule)

### DIFF
--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -79,7 +79,8 @@
 
     <record id="ir_rule_stock_picking_allowed_picking_type_operating_units" model="ir.rule">
         <field name="model_id" ref="stock.model_stock_picking"/>
-        <field name="domain_force">['|',
+        <field name="domain_force">['|','|',
+            ('picking_type_id.warehouse_id','=', False),
             ('picking_type_id.warehouse_id.operating_unit_id','=',False),
             ('picking_type_id.warehouse_id.operating_unit_id','in',user.operating_unit_ids.ids)]
         </field>


### PR DESCRIPTION
If the picking type is not part of a particular warehouse (like dropshipping) then errors will happen on purchase orders if dropshipping is chosen. This modifies the record rule to allow dropshipping (and other general, non-warehouse specific picking types) to work again on purchase orders.