### PR TITLE
[IMP] Check Stock Move OU Logic Rework

### DIFF
--- a/stock_operating_unit/models/stock_move.py
+++ b/stock_operating_unit/models/stock_move.py
@@ -17,26 +17,47 @@ class StockMove(models.Model):
         string='Dest. Location Operating Unit',
     )
 
+    # @api.multi
+    # @api.constrains('picking_id', 'location_id', 'location_dest_id')
+    # def _check_stock_move_operating_unit(self):
+    #     for stock_move in self:
+    #         if not stock_move.operating_unit_id:
+    #             return True
+    #         operating_unit = stock_move.operating_unit_id
+    #         operating_unit_dest = stock_move.operating_unit_dest_id
+    #         if (stock_move.location_id and
+    #             stock_move.location_id.operating_unit_id and
+    #             stock_move.picking_id and
+    #             operating_unit != stock_move.picking_id.operating_unit_id
+    #             ) and (
+    #             stock_move.location_dest_id and
+    #             stock_move.location_dest_id.operating_unit_id and
+    #             stock_move.picking_id and
+    #             operating_unit_dest != stock_move.picking_id.operating_unit_id
+    #         ):
+    #             raise UserError(
+    #                 _('Configuration error. The Stock moves must '
+    #                   'be related to a location (source or destination) '
+    #                   'that belongs to the requesting Operating Unit.')
+    #             )
+
+
     @api.multi
     @api.constrains('picking_id', 'location_id', 'location_dest_id')
     def _check_stock_move_operating_unit(self):
         for stock_move in self:
-            if not stock_move.operating_unit_id:
-                return True
             operating_unit = stock_move.operating_unit_id
+            operating_unit_source = stock_move.location_id.operating_unit_id
             operating_unit_dest = stock_move.operating_unit_dest_id
-            if (stock_move.location_id and
-                stock_move.location_id.operating_unit_id and
-                stock_move.picking_id and
-                operating_unit != stock_move.picking_id.operating_unit_id
-                ) and (
-                stock_move.location_dest_id and
-                stock_move.location_dest_id.operating_unit_id and
-                stock_move.picking_id and
-                operating_unit_dest != stock_move.picking_id.operating_unit_id
-            ):
+            operating_unit_picking = stock_move.picking_id.operating_unit_id
+            if not operating_unit_source or not operating_unit_dest or \
+                    not operating_unit_picking:
+                return True
+            if (operating_unit_source != operating_unit and \
+                    operating_unit_dest != operating_unit):
                 raise UserError(
                     _('Configuration error. The Stock moves must '
                       'be related to a location (source or destination) '
                       'that belongs to the requesting Operating Unit.')
                 )
+


### PR DESCRIPTION
We have encountered an error with the logic in this function partially because the error message does not properly reflect what the method is checking. 

In order to make these locations accessible to multiple OU's we believe that if thier OU is set to False then anyone should be able to make a Stock Move to them. That is logic behind the first "If" statement. 

The 2nd "If" statement says that if the source location and the destination location and the stock move have an OU set, then the Stock Move should match at least 1 of the locations, just as the error message says.

I left the original method commented above so hopefully it is easier to comapre the 2 methods instead without the github changes.