### PR TITLE
[13.0][IMP] Add some feature in account_operating_unit module

### DIFF
--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -224,9 +224,24 @@ class AccountMove(models.Model):
                 and move.operating_unit_id
                 and move.operating_unit_id != move.journal_id.operating_unit_id
             ):
-                raise UserError(
-                    _("The OU in the Move and in Journal must be the same.")
-                )
+                # Change journal_id if create move from other model. e.g., sale.order
+                if (
+                    move._context.get("active_model")
+                    and move._context.get("active_model") != "account.move"
+                ):
+                    move._onchange_operating_unit()
+                    if (
+                        move.journal_id.operating_unit_id
+                        and move.operating_unit_id
+                        and move.operating_unit_id != move.journal_id.operating_unit_id
+                    ):
+                        raise UserError(
+                            _("The OU in the Move and in Journal must be the same.")
+                        )
+                else:
+                    raise UserError(
+                        _("The OU in the Move and in Journal must be the same.")
+                    )
         return True
 
     @api.constrains("operating_unit_id", "company_id")

--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -53,7 +53,6 @@ class AccountMoveLine(models.Model):
         for rec in self:
             if (
                 rec.move_id
-                and rec.move_id.type == "entry"
                 and rec.move_id.operating_unit_id
                 and rec.operating_unit_id
                 and rec.move_id.operating_unit_id != rec.operating_unit_id
@@ -90,10 +89,11 @@ class AccountMove(models.Model):
 
     @api.onchange("invoice_line_ids")
     def _onchange_invoice_line_ids(self):
+        res = super()._onchange_invoice_line_ids()
         if self.operating_unit_id:
             for line in self.line_ids:
                 line.operating_unit_id = self.operating_unit_id
-        return super()._onchange_invoice_line_ids()
+        return res
 
     @api.onchange("operating_unit_id")
     def _onchange_operating_unit(self):
@@ -226,5 +226,21 @@ class AccountMove(models.Model):
             ):
                 raise UserError(
                     _("The OU in the Move and in Journal must be the same.")
+                )
+        return True
+
+    @api.constrains("operating_unit_id", "company_id")
+    def _check_company_operating_unit(self):
+        for move in self:
+            if (
+                move.company_id
+                and move.operating_unit_id
+                and move.company_id != move.operating_unit_id.company_id
+            ):
+                raise UserError(
+                    _(
+                        "The Company in the Move and in "
+                        "Operating Unit must be the same."
+                    )
                 )
         return True

--- a/account_operating_unit/views/account_move_view.xml
+++ b/account_operating_unit/views/account_move_view.xml
@@ -65,8 +65,30 @@
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
+            <field name="invoice_line_ids" position="attributes">
+                <attribute
+                    name="context"
+                >{'default_type': context.get('default_type'), 'journal_id': journal_id, 'default_partner_id': commercial_partner_id, 'default_currency_id': currency_id != company_currency_id and currency_id or False, 'operating_unit_id': operating_unit_id}</attribute>
+            </field>
+            <xpath
+                expr="//field[@name='invoice_line_ids']/tree/field[@name='analytic_account_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="domain"
+                >['|', ('company_id', '=', False), ('company_id', '=', parent.company_id), '|', ('operating_unit_ids', '=', context.get('operating_unit_id', False)), ('operating_unit_ids', '=', False)]</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='invoice_line_ids']/form/sheet/group/field[@name='analytic_account_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="domain"
+                >['|', ('operating_unit_ids', '=', context.get('operating_unit_id', False)), ('operating_unit_ids', '=', False)]</attribute>
+            </xpath>
             <field name="line_ids" position="attributes">
                 <attribute name="context">{
+                    'default_type': context.get('default_type'),
                     'line_ids': line_ids,
                     'journal_id': journal_id,
                     'default_partner_id': commercial_partner_id,
@@ -84,6 +106,59 @@
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </xpath>
+            <xpath
+                expr="//field[@name='line_ids']/tree/field[@name='analytic_account_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="domain"
+                >['|', ('company_id', '=', parent.company_id), ('company_id', '=', False), '|', ('operating_unit_ids', '=', context.get('default_operating_unit_id', False)), ('operating_unit_ids', '=', False)]</attribute>
+            </xpath>
+            <xpath
+                expr="//field[@name='line_ids']/form/group/field[@name='analytic_account_id']"
+                position="attributes"
+            >
+                <attribute
+                    name="domain"
+                >['|', ('operating_unit_ids', '=', context.get('default_operating_unit_id', False)), ('operating_unit_ids', '=', False)]</attribute>
+            </xpath>
+        </field>
+    </record>
+    <record id="view_invoice_tree" model="ir.ui.view">
+        <field name="name">account.invoice.tree</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_invoice_tree" />
+        <field name="arch" type="xml">
+            <field name="company_id" position="before">
+                <field
+                    name="operating_unit_id"
+                    options="{'no_create': True}"
+                    groups="operating_unit.group_multi_operating_unit"
+                />
+            </field>
+        </field>
+    </record>
+    <record id="view_account_invoice_filter" model="ir.ui.view">
+        <field name="name">account.invoice.select</field>
+        <field name="model">account.move</field>
+        <field name="inherit_id" ref="account.view_account_invoice_filter" />
+        <field name="arch" type="xml">
+            <field name="invoice_user_id" position="after">
+                <field
+                    name="operating_unit_id"
+                    groups="operating_unit.group_multi_operating_unit"
+                />
+            </field>
+            <filter name="salesperson" position="after">
+                <filter
+                    string="Operating Unit"
+                    name="operating_unit_grouped"
+                    icon="terp-folder-orange"
+                    domain="[]"
+                    groups="operating_unit.group_multi_operating_unit"
+                    context="{'group_by':'operating_unit_id'}"
+                />
+            </filter>
         </field>
     </record>
 </odoo>

--- a/account_operating_unit/views/account_payment_view.xml
+++ b/account_operating_unit/views/account_payment_view.xml
@@ -45,6 +45,7 @@
             <field name="journal_id" position="after">
                 <field
                     name="operating_unit_id"
+                    options="{'no_create': True}"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>


### PR DESCRIPTION
- _check_move_operating_unit for all move types
- When you add invoice line operating unit should show in journal item immediately (not after save)
- Check company in move and operating unit must equal
- Filter analytic account in move line with operating unit on move
- Add operating unit in invoice's tree view
- Add search and group by in invoice