### PR TITLE
[12.0][FIX] stock_operating_unit depends on operating_unit

### DIFF
--- a/stock_operating_unit/__manifest__.py
+++ b/stock_operating_unit/__manifest__.py
@@ -12,7 +12,7 @@
               "Odoo Community Association (OCA)",
     "license": "LGPL-3",
     "website": "https://github.com/OCA/operating-unit",
-    "depends": ["stock", "account_operating_unit"],
+    "depends": ["stock", "operating_unit"],
     "data": [
         "security/stock_security.xml",
         "data/stock_data.xml",


### PR DESCRIPTION
Not depending on account_operating_unit but only operating_unit make it applicable to access warehouses with users restrictions