### PR TITLE
[IMP] stock_operating_unit: Check Destination Location OU is Set

### DIFF
--- a/stock_operating_unit/models/stock_move.py
+++ b/stock_operating_unit/models/stock_move.py
@@ -24,7 +24,7 @@ class StockMove(models.Model):
             ou_pick = stock_move.picking_id.operating_unit_id or False
             ou_src = stock_move.operating_unit_id or False
             ou_dest = stock_move.operating_unit_dest_id or False
-            if ou_src and ou_pick and (ou_src != ou_pick) and \
+            if ou_src and ou_pick and ou_dest and (ou_src != ou_pick) and \
                     (ou_dest != ou_pick):
                 raise UserError(_(
                     "Configuration error. The stock move must be related to "


### PR DESCRIPTION
Small change here, if an OU is False if a source location or a destination location does not have an OU then that means anything can come from/to those locations. We are consistent with source location but we are not checking to see if destination OU is set. This causes an error when users are trying to push to a location with no OU set and still getting this error thrown.