### PR TITLE
[10.0][FIX]stock operating_unit security

### DIFF
--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -60,4 +60,18 @@
         <field eval="0" name="perm_create"/>
     </record>
 
+    <record id="ir_rule_stock_picking_allowed_picking_type_operating_units" model="ir.rule">
+        <field name="model_id" ref="stock.model_stock_picking"/>
+        <field name="domain_force">['|','|',
+            ('picking_type_id.warehouse_id','=', False),
+            ('picking_type_id.warehouse_id.operating_unit_id','=',False),
+            ('picking_type_id.warehouse_id.operating_unit_id','in',user.operating_unit_ids.ids)]
+        </field>
+        <field name="name">Stock pickings from allowed picking types</field>
+        <field name="global" eval="True"/>
+        <field eval="0" name="perm_unlink"/>
+        <field eval="0" name="perm_write"/>
+        <field eval="1" name="perm_read"/>
+        <field eval="0" name="perm_create"/>
+    </record>
 </odoo>

--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -16,7 +16,11 @@
 
     <record id="ir_rule_stock_picking_type_allowed_operating_units" model="ir.rule">
         <field name="model_id" ref="stock.model_stock_picking_type"/>
-        <field name="domain_force">['|',('warehouse_id.operating_unit_id','=',False),('warehouse_id.operating_unit_id','in',[g.id for g in user.operating_unit_ids])]</field>
+        <field name="domain_force">['|','|',
+            ('warehouse_id','=', False),
+            ('warehouse_id.operating_unit_id','=',False),
+            ('warehouse_id.operating_unit_id','in',user.operating_unit_ids.ids)]
+        </field>
         <field name="name">Stock Picking Type from allowed operating units</field>
         <field name="global" eval="True"/>
         <field eval="0" name="perm_unlink"/>
@@ -74,4 +78,5 @@
         <field eval="1" name="perm_read"/>
         <field eval="0" name="perm_create"/>
     </record>
+
 </odoo>


### PR DESCRIPTION
Supersedes #299 

Backport of:

https://github.com/OCA/operating-unit/pull/267/
and
https://github.com/OCA/operating-unit/pull/233/