### PR TITLE
[FIX]stock_operating_unit: Fixed an issue of record rule for 'Stock Picking Type from allowed operating units.'

### DIFF
--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -18,7 +18,8 @@
     </record>
     <record id="ir_rule_stock_picking_type_allowed_operating_units" model="ir.rule">
         <field name="model_id" ref="stock.model_stock_picking_type" />
-        <field name="domain_force">['|',
+        <field name="domain_force">['|','|',
+            ('warehouse_id','=', False),
             ('warehouse_id.operating_unit_id','=', False),
             ('warehouse_id.operating_unit_id','in',user.operating_unit_ids.ids)]
         </field>


### PR DESCRIPTION
Fixed an issue when we're going to create the purchase order and that purchase order '`picking_type_id`' doesn't set the  '`warehouse`' field than it's getting pop-up the below Warning

```
The requested operation ("read" on "Picking Type" (stock.picking.type)) was rejected because of the
following rules:
- Stock Picking Type from allowed operating units

(Records: Receipts (id=1), User: Mitchell Admin (id=2)) 
```

![P00024 - Odoo](https://user-images.githubusercontent.com/16575953/87400905-0faf2b00-c5d7-11ea-83bf-3a54cc9dd6a0.gif)
