### PR TITLE
[12.0][FIX] purchase_operating_unit

### DIFF
--- a/purchase_operating_unit/tests/test_purchase_operating_unit.py
+++ b/purchase_operating_unit/tests/test_purchase_operating_unit.py
@@ -32,7 +32,7 @@ class TestPurchaseOperatingUnit(common.TransactionCase):
         self.product2 = self.env.ref('product.product_product_9')
         self.product3 = self.env.ref('product.product_product_11')
         # Account
-        self.account = self.env.ref('l10n_generic_coa.conf_a_pay')
+        self.account = self.partner1.property_account_payable_id
         # Create users
         self.user1_id = self._create_user('user_1',
                                           [self.group_purchase_user,


### PR DESCRIPTION
OCA_test odoo.sql_db: bad query: INSERT INTO "account_invoice" ("id", "create_uid", "create_date", "write_uid", "write_date", "account_id", "comment", "company_id", "currency_id", "incoterm_id", "journal_id", "move_name", "operating_unit_id", "partner_id", "payment_term_id", "purchase_id", "reconciled", "sent", "state", "team_id", "type", "user_id") VALUES (nextval('account_invoice_id_seq'), 1, (now() at time zone 'UTC'), 1, (now() at time zone 'UTC'), 13, NULL, 1, 2, NULL, 52, NULL, 1, 9, 6, 72, false, false, 'draft', 1, 'in_invoice', 1) RETURNING id
ERROR: insert or update on table "account_invoice" violates foreign key constraint "account_invoice_account_id_fkey"
DETAIL:  Key (account_id)=(13) is not present in table "account_account".

/purchase_operating_unit/tests/test_purchase_operating_unit.py", line 52, in setUp 
2020-07-16 09:57:49,036 12491 ERROR OCA_test odoo.addons.purchase_operating_unit.tests.test_po_security: `     self._create_invoice(self.purchase1, self.partner1, self.account) 