### PR TITLE
[12.0][FIX] res_partner complete filter also in name search

### DIFF
--- a/res_partner_operating_unit/models/res_partner.py
+++ b/res_partner_operating_unit/models/res_partner.py
@@ -39,7 +39,16 @@ class ResPartner(models.Model):
                   ('operating_unit_ids', '=', False)]
         return super().search(domain + args, offset=offset, limit=limit,
                               order=order, count=count)
-
+    @api.model
+    def name_search(self, name, args=None, operator='ilike', limit=100):
+        args = args or []
+        # Get the OUs of the user
+        ou_ids = self.env.user.operating_unit_ids.ids
+        domain = ['|',
+                  ('operating_unit_ids', 'in', ou_ids),
+                  ('operating_unit_ids', '=', False)]
+        return super().name_search(name, domain + args, operator=operator, limit=limit)
+    
     @api.model
     def search_count(self, args):
         # Get the OUs of the user


### PR DESCRIPTION
if you start to insert a partner you visualize all, with this you immediately filter partner by operating-unit 