### PR TITLE
[13.0]fix operating_unit record rules

### DIFF
--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -24,16 +24,43 @@ class ResUsers(models.Model):
     def _default_operating_units(self):
         return self._default_operating_unit()
 
-    operating_unit_ids = fields.Many2many(
-        "operating.unit",
-        "operating_unit_users_rel",
-        "user_id",
-        "operating_unit_id",
-        "Operating Units",
+    operating_unit_ids = fields.One2many(
+        comodel_name="operating.unit",
+        compute="_compute_operating_unit_ids",
+        inverse="_inverse_operating_unit_ids",
+    )
+    assigned_operating_unit_ids = fields.Many2many(
+        comodel_name="operating.unit",
+        relation="operating_unit_users_rel",
+        column1="user_id",
+        column2="operating_unit_id",
+        string="Operating Units",
         default=lambda self: self._default_operating_units(),
     )
+
     default_operating_unit_id = fields.Many2one(
-        "operating.unit",
-        "Default Operating Unit",
+        comodel_name="operating.unit",
+        string="Default Operating Unit",
         default=lambda self: self._default_operating_unit(),
     )
+
+    @api.depends("groups_id", "assigned_operating_unit_ids")
+    def _compute_operating_unit_ids(self):
+        for user in self:
+            if user.has_group("operating_unit.group_manager_operating_unit"):
+                dom = []
+                if self.env.context.get("allowed_company_ids"):
+                    dom = [
+                        "|",
+                        ("company_id", "=", False),
+                        ("company_id", "in", self.env.context["allowed_company_ids"]),
+                    ]
+                else:
+                    dom = []
+                user.operating_unit_ids = self.env["operating.unit"].sudo().search(dom)
+            else:
+                user.operating_unit_ids = user.assigned_operating_unit_ids
+
+    def _inverse_operating_unit_ids(self):
+        for user in self:
+            user.assigned_operating_unit_ids = user.operating_unit_ids

--- a/operating_unit/security/operating_unit_security.xml
+++ b/operating_unit/security/operating_unit_security.xml
@@ -33,16 +33,5 @@
         <field eval="0" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
-        <field name="groups" eval="[(4, ref('group_multi_operating_unit'))]" />
-    </record>
-    <record id="rule_operating_unit_manager" model="ir.rule">
-        <field name="name">Operating Unit Manager</field>
-        <field name="model_id" ref="model_operating_unit" />
-        <field name="domain_force">[(1, '=', 1)]</field>
-        <field name="perm_read" eval="True" />
-        <field name="perm_write" eval="True" />
-        <field name="perm_create" eval="True" />
-        <field name="perm_unlink" eval="True" />
-        <field name="groups" eval="[(4, ref('group_manager_operating_unit'))]" />
     </record>
 </odoo>

--- a/operating_unit/tests/test_operating_unit.py
+++ b/operating_unit/tests/test_operating_unit.py
@@ -70,7 +70,13 @@ class TestOperatingUnit(common.TransactionCase):
             .search([])
             .mapped("code")
         )
-        nou = self.env["operating.unit"].search([])
+        nou = self.env["operating.unit"].search(
+            [
+                "|",
+                ("company_id", "=", False),
+                ("company_id", "in", self.user1.company_ids.ids),
+            ]
+        )
         self.assertEqual(
             len(operating_unit_list_1),
             len(nou),


### PR DESCRIPTION
In the 12.0 migration of this module the record rules got changed without any explanation why.
Imho this change is not required and is also confusing since the module now adds group level record rules but the group is a technical usability group to hide the operating unit fields from the User Interface.

I have done a couple of tests with the record rules coming with this PR and I didn't find any issue (and also didn't expect any issue since the 'old' record rules have worked correctly up to oca/operating_unit 11.0).

Maybe I am missing something but if not than I think we should restore the record rules to how it was up to the 12.0 port.
