### PR TITLE
[FIX] proper calculation of request_line_ids from active_model

### DIFF
--- a/purchase_request_operating_unit/wizard/purchase_request_line_make_purchase_order.py
+++ b/purchase_request_operating_unit/wizard/purchase_request_line_make_purchase_order.py
@@ -22,7 +22,16 @@ class PurchaseRequestLineMakePurchaseOrder(models.TransientModel):
         res = super(PurchaseRequestLineMakePurchaseOrder, self).\
             default_get(fields)
         request_line_obj = self.env['purchase.request.line']
-        request_line_ids = self._context.get('active_ids', [])
+        active_model = self.env.context.get('active_model', False)
+        request_line_ids = []
+        if active_model == 'purchase.request.line':
+            request_line_ids += self.env.context.get('active_ids', [])
+        elif active_model == 'purchase.request':
+            request_ids = self.env.context.get('active_ids', False)
+            request_line_ids += self.env[active_model].browse(
+                request_ids).mapped('line_ids.id')
+        if not request_line_ids:
+            return res
         operating_unit_id = False
         for line in request_line_obj.browse(request_line_ids):
             line_operating_unit_id = line.request_id.operating_unit_id \


### PR DESCRIPTION
the default_get method supposes that 'active_ids' is the id of the purchase request lines. Which is not the case when the wizard is called from the purchase request. This PR fixes it by testing on 'active_model' and making proper calculations.
See: OCA/purchase-workflow@4fe3697#diff-e458197a92be2847dc330973def5bc39