### PR TITLE
[IMP] sales_team_operating_unit v12: Adding default operating unit for existing demo Sales Team

### DIFF
--- a/sales_team_operating_unit/__manifest__.py
+++ b/sales_team_operating_unit/__manifest__.py
@@ -15,6 +15,7 @@
     "depends": ["sales_team", "operating_unit"],
     "data": [
         "security/crm_security.xml",
+        "demo/sales_team_demo.xml",
         "views/crm_team_view.xml",
     ],
     'installable': True,

--- a/sales_team_operating_unit/demo/sales_team_demo.xml
+++ b/sales_team_operating_unit/demo/sales_team_demo.xml
@@ -1,0 +1,7 @@
+<odoo>
+    <data noupdate="0">
+        <record id="sales_team.team_sales_department" model="crm.team">
+            <field name="operating_unit_id" ref="operating_unit.main_operating_unit"/>
+        </record>
+    </data>
+</odoo>


### PR DESCRIPTION
This will fix the issue #316 
When using demo sales Team Europe, it will already have the main operating unit assigned, not breaking then the constraints about SO and Sales Team should have the same operating unit. 
@gdgellatly @AaronHForgeFlow 