### PR TITLE
Show related documents even if the operating unit is inactive

### DIFF
--- a/sale_operating_unit/security/sale_security.xml
+++ b/sale_operating_unit/security/sale_security.xml
@@ -7,7 +7,7 @@
     <record id="ir_rule_sale_order_allowed_operating_units"
             model="ir.rule">
         <field name="model_id" ref="sale.model_sale_order"/>
-        <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
+        <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in', user.with_context(active_test=False).operating_unit_ids.ids)]</field>
         <field name="name">Sales Orders from allowed operating units</field>
         <field name="global" eval="True"/>
         <field eval="0" name="perm_unlink"/>
@@ -19,7 +19,7 @@
     <record id="ir_rule_sale_order_line_allowed_operating_units"
             model="ir.rule">
         <field name="model_id" ref="sale.model_sale_order_line"/>
-        <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
+        <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in', user.with_context(active_test=False).operating_unit_ids.ids)]</field>
         <field name="name">Sales Order lines from allowed operating units</field>
         <field name="global" eval="True"/>
         <field eval="0" name="perm_unlink"/>
@@ -31,7 +31,7 @@
     <record id="ir_rule_sale_report_allowed_operating_units"
             model="ir.rule">
         <field name="model_id" ref="sale.model_sale_report"/>
-        <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
+        <field name="domain_force">['|',('operating_unit_id','=',False),('operating_unit_id','in', user.with_context(active_test=False).operating_unit_ids.ids)]</field>
         <field name="name">Sales Report from allowed operating units</field>
         <field name="global" eval="True"/>
         <field eval="0" name="perm_unlink"/>


### PR DESCRIPTION
When deactivating an operating unit, the related documents should still be visible to the appropriate users