### PR TITLE
[12.0][FIX] store computed field used in domain

### DIFF
--- a/sale_operating_unit/models/sale_order.py
+++ b/sale_operating_unit/models/sale_order.py
@@ -68,4 +68,5 @@ class SaleOrderLine(models.Model):
     _inherit = 'sale.order.line'
 
     operating_unit_id = fields.Many2one(related='order_id.operating_unit_id',
+                                        store=True,
                                         string='Operating Unit')


### PR DESCRIPTION
in a database with a lot of sale.order.line records, the ir.rule https://github.com/OCA/operating-unit/blob/2a4d17dab33feab02c8ab109b89e0e18348bac77/sale_operating_unit/security/sale_security.xml#L22 is applied on a computed non-stored field, which considerably slows down the navigation between Sale Order in form view.

This fix is intended to store the computed field so that the domain check will be only a select from a single table instead of a join from two.