### PR TITLE
[10.0][FIX] hr_payroll_account_operating_unit

### DIFF
--- a/hr_payroll_account_operating_unit/models/account_move.py
+++ b/hr_payroll_account_operating_unit/models/account_move.py
@@ -16,7 +16,7 @@ class AccountMove(models.Model):
     @api.constrains('operating_unit_id')
     def check_payslips_ou(self):
         for move in self:
-            pay = self.env['hr.payslip'].search(
+            pay = self.env['hr.payslip'].sudo().search(
                 [('move_id', '=', move.id)])
             if ((pay.operating_unit_id and move.operating_unit_id)
                     and (pay.operating_unit_id != move.operating_unit_id)):


### PR DESCRIPTION
* constraint giving incorrect access error:

```
Odoo Warning - Validation Error

Error while validating constraint

Sorry, you are not allowed to access this document. Only users with the following access level are currently allowed to do that:
- Payroll/Officer

(Document model: hr.payslip) - (Operation: read, User: 30)

```


@ForgeFlow