### PR TITLE
[13.0][FIX] purchase_operating_unit: pass correct journal when invoice is created from purchase order

### DIFF
--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -119,6 +119,21 @@ class PurchaseOrder(models.Model):
         picking_vals["operating_unit_id"] = self.operating_unit_id.id
         return picking_vals
 
+    def action_view_invoice(self):
+        result = super().action_view_invoice()
+        company_id = self._context.get(
+            "force_company",
+            self._context.get("default_company_id", self.env.company.id),
+        )
+        domain = [
+            ("company_id", "=", company_id),
+            ("type", "=", "purchase"),
+            ("operating_unit_id", "=", self.operating_unit_id.id),
+        ]
+        journal = self.env["account.journal"].search(domain, limit=1)
+        result["context"]["default_journal_id"] = journal.id
+        return result
+
 
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"

--- a/purchase_operating_unit/readme/CONTRIBUTORS.rst
+++ b/purchase_operating_unit/readme/CONTRIBUTORS.rst
@@ -3,3 +3,5 @@
 * Sudhir Arya <sudhir.arya@serpentcs.com>
 * Nicola Studer <nicola.studer@braintec-group.com>
 * Nikul Chaudhary <nikul.chaudhary.serpentcs@gmail.com>
+* Aldo Nerio <aldo.nerio@jarsa.com.mx>
+* Alan Ramos <alan.ramos@jarsa.com.mx>


### PR DESCRIPTION
### Proposed changes

This fixes the following issue:
- Configure user to have multiple operating units, and define it to several operating units.
- Create a purchase order for OU1.
- Confirm purchase order and create an invoice.

Expected behavior:
- The invoice must contain a purchase journal of the operating unit of the purchase order.

Current behavior:
- The invoice gets the first purchase journal that it found, even if the operating unit is not of the purchase order.

### Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Migration Update

### Checklist

- [x] I have read the CONTRIBUTING doc
- [x] I have signed the CLA
- [x] Lint and unit tests pass locally with my changes
- [x] I have updated the necessary documentation
