### PR TITLE
[13.0][FIX] hr_expense_operating_unit: multi operating-unit can't create expense sheet

### DIFF
--- a/hr_expense_operating_unit/readme/CONTRIBUTORS.rst
+++ b/hr_expense_operating_unit/readme/CONTRIBUTORS.rst
@@ -1,3 +1,4 @@
 * Jordi Ballester Alomar <jordi.ballester@forgeflow.com>
 * Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
 * Jarsa Sistemas <info@jarsa.com.mx>
+* Saran Lim. <saranl@ecosoft.co.th>


### PR DESCRIPTION
Step to error:
1. Create expense from My Expenses
2. Change default operating unit.
3. Create Report
4. It throw error `Configuration error. The Operating Unit in the Expense sheet and in the Expense must be the same.`

Solve it by send operating unit from `hr.expense` to `hr.expense.sheet`