### PR TITLE
[13.0][FIX] hr_expense_operating_unit: default ou on move

### DIFF
--- a/hr_expense_operating_unit/models/hr_expense.py
+++ b/hr_expense_operating_unit/models/hr_expense.py
@@ -67,11 +67,16 @@ class HrExpenseExpense(models.Model):
         return sheet
 
     def _get_account_move_line_values(self):
-        res = super(HrExpenseExpense, self)._get_account_move_line_values()
+        res = super()._get_account_move_line_values()
         for expense in self:
             res[expense.id][0].update({"operating_unit_id": self.operating_unit_id.id})
             res[expense.id][1].update({"operating_unit_id": self.operating_unit_id.id})
         return res
+
+    def _prepare_move_values(self):
+        move_values = super()._prepare_move_values()
+        move_values["operating_unit_id"] = self.operating_unit_id.id
+        return move_values
 
 
 class HrExpenseSheet(models.Model):


### PR DESCRIPTION
Step to error:

1. Create expense from My Expenses with operating unit
2. Create Report > Submit to Manager > Approve > Post Journal Entries
![Selection_005](https://user-images.githubusercontent.com/20896369/115518821-cf41b380-a2b2-11eb-8764-dc6ea90d1506.png)

3. Look at journal entry > operating unit on move is empty
![Selection_006](https://user-images.githubusercontent.com/20896369/115518835-d2d53a80-a2b2-11eb-84d0-a22697c169c7.png)
