### PR TITLE
[14.0][IMP] purchase_operating_unit, speciall access all OU docs

### DIFF
--- a/operating_unit/security/operating_unit_security.xml
+++ b/operating_unit/security/operating_unit_security.xml
@@ -4,6 +4,10 @@
         <field name="name">Operating Units Group</field>
         <field name="sequence">30</field>
     </record>
+    <record id="module_category_all_operating_unit" model="ir.module.category">
+        <field name="name">Access all operating units' documents</field>
+        <field name="sequence">35</field>
+    </record>
     <record id="group_multi_operating_unit" model="res.groups">
         <field name="name">Multiple Operating Unit</field>
         <field name="category_id" ref="module_operating_units" />

--- a/purchase_operating_unit/security/purchase_security.xml
+++ b/purchase_operating_unit/security/purchase_security.xml
@@ -8,7 +8,7 @@
         <field name="model_id" ref="purchase.model_purchase_order" />
         <field
             name="domain_force"
-        >['|',('operating_unit_id','=',False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
+        >['|','|',(1, '=', user.has_group('purchase_operating_unit.group_all_operating_unit_purchase')),('operating_unit_id','=',False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
         <field name="name">PO's from allowed operating units</field>
         <field name="global" eval="True" />
         <field eval="0" name="perm_unlink" />
@@ -20,12 +20,19 @@
         <field name="model_id" ref="purchase.model_purchase_order_line" />
         <field
             name="domain_force"
-        >['|',('operating_unit_id','=',False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
+        >['|','|',(1, '=', user.has_group('purchase_operating_unit.group_all_operating_unit_purchase')),('operating_unit_id','=',False),('operating_unit_id','in', user.operating_unit_ids.ids)]</field>
         <field name="name">PO lines from allowed operating units</field>
         <field name="global" eval="True" />
         <field eval="0" name="perm_unlink" />
         <field eval="0" name="perm_write" />
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
+    </record>
+    <record id="group_all_operating_unit_purchase" model="res.groups">
+        <field name="name">Purchase</field>
+        <field
+            name="category_id"
+            ref="operating_unit.module_category_all_operating_unit"
+        />
     </record>
 </odoo>


### PR DESCRIPTION
This small enhancement enable user to access all operating units' purchase orders, even without all OU access

Assume this user has only access to 1 OU from 5 OUs

![image](https://user-images.githubusercontent.com/1973598/120110069-63e2df80-c196-11eb-8d92-743383e6bc24.png)

In all modules, except Purchase, user should have access to only 1 OU. We can enable special access only for purchase documents only.

![image](https://user-images.githubusercontent.com/1973598/120110208-c4721c80-c196-11eb-9a39-b68ec90fc7e0.png)

Note:
* This is the enhancement that need to be done on all xxx_operating_unit modules.
* Instead of doing custom module, I think this better be included.

@AaronHForgeFlow @JordiBForgeFlow  WDYT?