### PR TITLE
[14.0][FIX] purchase_operating_unit, add OU when create invoice

### DIFF
--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -119,6 +119,11 @@ class PurchaseOrder(models.Model):
         picking_vals["operating_unit_id"] = self.operating_unit_id.id
         return picking_vals
 
+    def _prepare_invoice(self):
+        invoice_vals = super()._prepare_invoice()
+        invoice_vals["operating_unit_id"] = self.operating_unit_id.id
+        return invoice_vals
+
 
 class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"


### PR DESCRIPTION
In v14, Create Bill is using purchase.action_create_invoice() to create invoice on background. And so, we also need to pass the OU in this process..

Note: v13, it was passing default_purcahse_id and use _onchange_purchase_auto_complete().

This can be FFW.