### PR TITLE
[FIX] wrong code when adding OU to related partner

### DIFF
--- a/res_partner_operating_unit/models/res_users.py
+++ b/res_partner_operating_unit/models/res_users.py
@@ -22,7 +22,7 @@ class ResUsers(models.Model):
         if vals.get('default_operating_unit_id'):
             # Add the new OU
             self.partner_id.operating_unit_ids = \
-                [(4, res.default_operating_unit_id.id)]
+                [(4, self.default_operating_unit_id.id)]
         return res
 
     @api.constrains('partner_id.operating_unit_ids',


### PR DESCRIPTION
res is super() result which will usually contains True. self must be used to compute the OU to add.

Current code gives the following error:
File "/OS/Users/Khalid/source/Odoo/OCA/operating-unit/res_partner_operating_unit/models/res_users.py", line 25, in write
    [(4, res.default_operating_unit_id.id)]
AttributeError: 'bool' object has no attribute 'default_operating_unit_id'