### PR TITLE
[14.0][FIX] purchase_operating_unit, wrong context

### DIFF
--- a/purchase_operating_unit/views/purchase_order_view.xml
+++ b/purchase_operating_unit/views/purchase_order_view.xml
@@ -34,7 +34,7 @@
             <field name="order_line" position="attributes">
                 <attribute
                     name="context"
-                >{'operating_unit_id': operating_unit_id}</attribute>
+                >{'default_state': 'draft', 'operating_unit_id': operating_unit_id}</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
The wrong context ignore {'default_state': 'draft}, which make `product_id` readonly on confirmed PO.

After this fix, now, it is possible to select product once again.

![image](https://user-images.githubusercontent.com/1973598/137887707-daba8cb8-a081-4991-877e-0c48219d9d82.png)
