### PR TITLE
[14.0][FIX]purchase_operating_unit: Operating Unit Issue when creating RFQ in Purchase App

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,7 +46,7 @@ repos:
           - --remove-duplicate-keys
           - --remove-unused-variables
   - repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/mirrors-prettier

--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -3,7 +3,7 @@
 # © 2015-17 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from odoo import _, api, fields, models
-from odoo.exceptions import UserError, ValidationError
+from odoo.exceptions import ValidationError
 
 
 class PurchaseOrder(models.Model):
@@ -106,12 +106,12 @@ class PurchaseOrder(models.Model):
             if types:
                 self.picking_type_id = types[:1]
             else:
-                raise UserError(
-                    _(
-                        "No Warehouse found with the Operating Unit indicated "
-                        "in the Purchase Order"
-                    )
-                )
+                warning = {
+                    "title": "%s Error" % self.operating_unit_id.name,
+                    "message": "No Warehouse found with the Operating Unit indicated "
+                    "in the Purchase Order",
+                }
+                return {"warning": warning}
 
     @api.model
     def _prepare_picking(self):

--- a/purchase_operating_unit/tests/test_purchase_operating_unit.py
+++ b/purchase_operating_unit/tests/test_purchase_operating_unit.py
@@ -6,6 +6,7 @@ import time
 
 from odoo.tests import common
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
+from odoo.exceptions import ValidationError
 
 
 class TestPurchaseOperatingUnit(common.TransactionCase):
@@ -98,6 +99,8 @@ class TestPurchaseOperatingUnit(common.TransactionCase):
                 "company_id": self.company1.id,
             }
         )
+        if purchase.operating_unit_id:
+            purchase._onchange_operating_unit_id()
         return purchase
 
     def _create_invoice(self, purchase, partner, account):

--- a/purchase_operating_unit/tests/test_purchase_operating_unit.py
+++ b/purchase_operating_unit/tests/test_purchase_operating_unit.py
@@ -99,7 +99,7 @@ class TestPurchaseOperatingUnit(common.TransactionCase):
             }
         )
         purchase._onchange_operating_unit_id()
-        self.assertTrue("warning" in purchase)
+        self.assertFalse("warning" in purchase)
         return purchase
 
     def _create_invoice(self, purchase, partner, account):

--- a/purchase_operating_unit/tests/test_purchase_operating_unit.py
+++ b/purchase_operating_unit/tests/test_purchase_operating_unit.py
@@ -6,7 +6,6 @@ import time
 
 from odoo.tests import common
 from odoo.tools import DEFAULT_SERVER_DATETIME_FORMAT
-from odoo.exceptions import ValidationError
 
 
 class TestPurchaseOperatingUnit(common.TransactionCase):
@@ -59,7 +58,7 @@ class TestPurchaseOperatingUnit(common.TransactionCase):
         self.invoice = self._create_invoice(self.purchase1, self.partner1, self.account)
 
     def _create_user(self, login, groups, company, operating_units):
-        """ Create a user."""
+        """Create a user."""
         group_ids = [group.id for group in groups]
         user = self.ResUsers.with_context({"no_reset_password": True}).create(
             {
@@ -104,7 +103,7 @@ class TestPurchaseOperatingUnit(common.TransactionCase):
         return purchase
 
     def _create_invoice(self, purchase, partner, account):
-        """ Create a vendor invoice for the purchase order."""
+        """Create a vendor invoice for the purchase order."""
         invoice_vals = {
             "purchase_id": purchase.id,
             "partner_id": partner.id,

--- a/purchase_operating_unit/tests/test_purchase_operating_unit.py
+++ b/purchase_operating_unit/tests/test_purchase_operating_unit.py
@@ -98,8 +98,8 @@ class TestPurchaseOperatingUnit(common.TransactionCase):
                 "company_id": self.company1.id,
             }
         )
-        if purchase.operating_unit_id:
-            purchase._onchange_operating_unit_id()
+        purchase._onchange_operating_unit_id()
+        self.assertTrue("warning" in purchase)
         return purchase
 
     def _create_invoice(self, purchase, partner, account):


### PR DESCRIPTION
If you have a default OU set on your user get the following error when creating a RFQ "No Warehouse found with the Operating Unit indicated in the Purchase Order"