### PR TITLE
[14.0][FIX] hr_expense_operating_unit: filter domain OU on expense

### DIFF
--- a/hr_expense_operating_unit/views/hr_expense_view.xml
+++ b/hr_expense_operating_unit/views/hr_expense_view.xml
@@ -30,6 +30,11 @@
                     options="{'no_create': True}"
                 />
             </field>
+            <xpath expr="//field[@name='analytic_account_id']" position="attributes">
+                <attribute name="domain">
+                    ['|', ('company_id', '=', company_id), ('company_id', '=', False), '|', ('operating_unit_ids', '=', operating_unit_id), ('operating_unit_ids', '=', False)]
+                </attribute>
+            </xpath>
         </field>
     </record>
     <record id="view_hr_expense_sheet_tree" model="ir.ui.view">


### PR DESCRIPTION
On expense, User can select `Analytic Account` difference OU.

Fix `Analytic Account` can select following operating unit or Analytic Account is not OU.
![Selection_004](https://user-images.githubusercontent.com/20896369/144781674-5f589108-fbd3-48ee-be13-1849cc3ce526.png)

