### PR TITLE
[14.0][FIX] hr_operating_unit: move OU to common employee

### DIFF
--- a/hr_operating_unit/models/__init__.py
+++ b/hr_operating_unit/models/__init__.py
@@ -1,4 +1,4 @@
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from . import hr_employee
+from . import hr_employee_base
 from . import hr_operating_unit

--- a/hr_operating_unit/models/hr_employee_base.py
+++ b/hr_operating_unit/models/hr_employee_base.py
@@ -3,20 +3,20 @@
 from odoo import fields, models
 
 
-class HrEmployee(models.Model):
-    _inherit = "hr.employee"
+class HrEmployeeBase(models.AbstractModel):
+    _inherit = "hr.employee.base"
 
     operating_unit_ids = fields.Many2many(
-        "operating.unit",
-        "operating_unit_employees_rel",
-        "employee_id",
-        "operating_unit_id",
-        "Operating Units",
+        comodel_name="operating.unit",
+        relation="operating_unit_employees_rel",
+        column1="employee_id",
+        column2="operating_unit_id",
+        string="Operating Units",
         default=lambda self: (self.env["res.users"].operating_unit_default_get()),
     )
 
     default_operating_unit_id = fields.Many2one(
-        "operating.unit",
-        "Default Operating Unit",
+        comodel_name="operating.unit",
+        string="Default Operating Unit",
         default=lambda self: (self.env["res.users"].operating_unit_default_get()),
     )


### PR DESCRIPTION
Bug:
if user don't have permission to Employee (officer or admin), user can't create expense.
and it show name double.
![Selection_001](https://user-images.githubusercontent.com/20896369/145144147-42712bd5-6b0d-4475-9286-c22b94f23daa.png)

This PR move on field OU from `hr.employee` to `hr.employee.base` (common between `hr.employee` and `hr.employee.public`)