### PR TITLE
[14.0][FIX] hr_expense_operating_unit: check OU on expense line difference

### DIFF
--- a/hr_expense_operating_unit/models/hr_expense.py
+++ b/hr_expense_operating_unit/models/hr_expense.py
@@ -81,8 +81,12 @@ class HrExpenseExpense(models.Model):
     def _get_account_move_line_values(self):
         res = super()._get_account_move_line_values()
         for expense in self:
-            res[expense.id][0].update({"operating_unit_id": self.operating_unit_id.id})
-            res[expense.id][1].update({"operating_unit_id": self.operating_unit_id.id})
+            res[expense.id][0].update(
+                {"operating_unit_id": expense.operating_unit_id.id}
+            )
+            res[expense.id][1].update(
+                {"operating_unit_id": expense.operating_unit_id.id}
+            )
         return res
 
     def _prepare_move_values(self):
@@ -107,6 +111,17 @@ class HrExpenseSheet(models.Model):
             self.expense_line_ids.write(
                 {"operating_unit_id": self.operating_unit_id.id}
             )
+
+    @api.constrains("operating_unit_id", "expense_line_ids")
+    def _check_expense_operating_unit(self):
+        for rec in self:
+            if len(rec.expense_line_ids.mapped("operating_unit_id")) > 1:
+                raise ValidationError(
+                    _(
+                        "Configuration error. The Operating "
+                        "Unit in the Expense Lines must be the same."
+                    )
+                )
 
     @api.constrains("operating_unit_id", "company_id")
     def _check_company_operating_unit(self):


### PR DESCRIPTION
[BUG] 
Can not `post journal entries` if OU are difference

Step to error

1. Create 2 expenses (OU1, OU2)
2. Create 1 report from 2 expenses
4. Delete Operating Unit in expense report (header)
4. Change Operating Unit in expense
![Selection_003](https://user-images.githubusercontent.com/20896369/146335948-d80759a7-b0f2-4bd6-a060-cc81598f35ff.png)
5. Save -> it should can't save
6. Submit to manager > Approve > Post Journal Entries
7. it's will error singleton
![Selection_004](https://user-images.githubusercontent.com/20896369/146336263-d15b65c0-f8ef-49ec-81e6-c9bd28cfee52.png)


[FIX]
- Add constrains on expense report. check ou on expense line must be the same.
- Fix update OU on move line from expense instead of self