### PR TITLE
[14.0] stock_operating_unit: Add Record Rule to Quants.

### DIFF
--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -104,4 +104,17 @@
         <field eval="1" name="perm_read" />
         <field eval="0" name="perm_create" />
     </record>
+    <record id="ir_rule_stock_quant_allowed_operating_units" model="ir.rule">
+        <field name="model_id" ref="stock.model_stock_quant" />
+        <field name="domain_force">['|',
+            ('location_id.operating_unit_id', '=', False),
+            ('location_id.operating_unit_id', 'in', user.operating_unit_ids.ids)]
+        </field>
+        <field name="name">Quants from allowed operating units</field>
+        <field name="global" eval="True" />
+        <field eval="0" name="perm_unlink" />
+        <field eval="0" name="perm_write" />
+        <field eval="1" name="perm_read" />
+        <field eval="0" name="perm_create" />
+    </record>
 </odoo>


### PR DESCRIPTION
Without this rule, a user will not be able to view the inventory report if they do not belong to all operating units of all the companies they belong.

Performance may be a cost here, in future versions we may want to store operating_unit_id on the quants directly as a relational stored field. 