### PR TITLE
[14.0][FIX] purchase_requisition_operating_unit: delete duplicate field

### DIFF
--- a/purchase_requisition_operating_unit/view/purchase_requisition.xml
+++ b/purchase_requisition_operating_unit/view/purchase_requisition.xml
@@ -36,7 +36,6 @@
                         groups="operating_unit.group_multi_operating_unit"
                         options="{'no_create': True}"
                     />
-                    <field name="picking_type_id" />
                 </field>
                 <xpath expr="//field[@name='line_ids']" position="attributes">
                     <attribute


### PR DESCRIPTION
Remove `picking_type_id` from view because it duplicates with `picking_type_id` of module **purchase_requisition_stock**.