### PR TITLE
[FIX] make default_operating_unit_id company_dependent

### DIFF
--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -41,6 +41,7 @@ class ResUsers(models.Model):
     default_operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         string="Default Operating Unit",
+        company_dependent=True,
         default=lambda self: self._default_operating_unit(),
     )
 


### PR DESCRIPTION
In a multi-company environment. We can assign a default operating unit to a user which is different than his current selected company. This makes it impossible to create records while connected to the second company.