### PR TITLE
[15.0][FIX] operating_unit: Default operating unit for template

### DIFF
--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -61,6 +61,22 @@ class ResUsers(models.Model):
             else:
                 user.operating_unit_ids = user.assigned_operating_unit_ids
 
+    @api.model
+    def default_get(self, fields):
+        vals = super(ResUsers, self).default_get(fields)
+        if (
+            self.env["ir.config_parameter"]
+            .sudo()
+            .get_param("base_setup.default_user_rights", "False")
+            == "True"
+        ):
+            default_user = self.env.ref("base.default_user")
+            vals[
+                "default_operating_unit_id"
+            ] = default_user.default_operating_unit_id.id
+            vals["operating_unit_ids"] = [(6, 0, default_user.operating_unit_ids.ids)]
+        return vals
+
     def _inverse_operating_unit_ids(self):
         for user in self:
             user.assigned_operating_unit_ids = user.operating_unit_ids

--- a/operating_unit/tests/test_operating_unit.py
+++ b/operating_unit/tests/test_operating_unit.py
@@ -3,6 +3,7 @@
 
 from odoo.exceptions import AccessError
 from odoo.tests import common
+from odoo.tests.common import Form
 
 
 class TestOperatingUnit(common.TransactionCase):
@@ -105,4 +106,17 @@ class TestOperatingUnit(common.TransactionCase):
             operating_unit_list_2[0],
             "B2C",
             "User 2 should have access to " "%s" % self.b2c.name,
+        )
+
+    def test_02_operating_unit(self):
+        self.env["ir.config_parameter"].sudo().set_param(
+            "base_setup.default_user_rights", "True"
+        )
+        user_form = Form(self.env["res.users"])
+        user_form.name = "Test Customer"
+        user_form.login = "test"
+        user = user_form.save()
+        default_user = self.env.ref("base.default_user")
+        self.assertEqual(
+            user.default_operating_unit_id, default_user.default_operating_unit_id
         )


### PR DESCRIPTION
Forward port of https://github.com/OCA/operating-unit/pull/491.