### PR TITLE
[13.0][FIX] sale_operating_unit: fix perfomance issues in sale order

### DIFF
--- a/sale_operating_unit/models/sale_order.py
+++ b/sale_operating_unit/models/sale_order.py
@@ -73,5 +73,5 @@ class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
     operating_unit_id = fields.Many2one(
-        related="order_id.operating_unit_id", string="Operating Unit"
+        related="order_id.operating_unit_id", string="Operating Unit", store=True,
     )


### PR DESCRIPTION
This PR makes the field operating_unit_id stored in sale order line model. 

This is required because it causes performance issues in databases with large number of sale.order records.

Without this change, if you open a sale order record with a database with 1 million records, it takes 20 seconds to open the sale.order.

With this change, it takes less than 1 second.
