### PR TITLE
[14.0][FIX] OperatingUnit.name_search() omits args domain in "other search"

### DIFF
--- a/operating_unit/models/operating_unit.py
+++ b/operating_unit/models/operating_unit.py
@@ -51,6 +51,8 @@ class OperatingUnit(models.Model):
         names2 = []
         if name:
             domain = [("code", "=ilike", name + "%")]
+            if args:
+                domain.extend(list(args))
             names2 = self.search(domain, limit=limit).name_get()
         # Merge both results
         return list(set(names1) | set(names2))[:limit]


### PR DESCRIPTION
Fix: omit domain passed in args to OperatingUnit.name_search() in "other search"

Currently when we create model with relation to operating.unit with domain (for example Many2one field with ('company_id','=',company_id) domain) and make field available in form view, users will be able to select only operating units that fulfill domain condition, unless they start to type name to field to search for it. Then all operating units that user have access to will be available, not taking into account domain condition. 

This PR fixes that issue.