### PR TITLE
[15.0][FWD][FIX] operating_unit: omit domain passed in args to OperatingUnit.name_search() in "other search"

### DIFF
--- a/operating_unit/models/operating_unit.py
+++ b/operating_unit/models/operating_unit.py
@@ -51,6 +51,8 @@ class OperatingUnit(models.Model):
         names2 = []
         if name:
             domain = [("code", "=ilike", name + "%")]
+            if args:
+                domain.extend(list(args))
             names2 = self.search(domain, limit=limit).name_get()
         # Merge both results
         return list(set(names1) | set(names2))[:limit]


### PR DESCRIPTION
Foward port of https://github.com/OCA/operating-unit/pull/524/