### PR TITLE
[15.0][FIX]-account_operating_unit: fix the error 'You are trying to …

### DIFF
--- a/account_operating_unit/wizards/account_payment_register.py
+++ b/account_operating_unit/wizards/account_payment_register.py
@@ -24,12 +24,12 @@ class AccountPaymentRegister(models.TransientModel):
                     )
                 )
             if reconciled_moves.operating_unit_id != payment.operating_unit_id:
-                destination_account = payments.destination_account_id
+                destination_account = payment.destination_account_id
                 to_reconcile |= payment.move_id.line_ids.filtered(
                     lambda l: l.account_id == destination_account
                 )
                 to_reconcile |= reconciled_moves.line_ids.filtered(
-                    lambda l: l.account_id == destination_account
+                    lambda l: l.account_id == destination_account and not l.reconciled
                 )
                 payment.action_draft()
                 line = payment.move_id.line_ids.filtered(


### PR DESCRIPTION
[15.0][FIX]-account_operating_unit: fix the error 'You are trying to reconcile some entries that are already reconciled'

"You are trying to reconcile some entries that are already reconciled" 
How to reproduce the issue:
1. Use Payment Term on Invoice, so Payable / Receivable Journal Item Line will be split to 2 lines.
2. Register Payment to pay the first Payable / Receivable Journal Item Line.
3. Second Register Payment will face the error above.

<img width="733" alt="image" src="https://user-images.githubusercontent.com/12895874/213079056-41c7af25-f66f-4b7b-b6f1-17c745b09663.png">
