### PR TITLE
[15.0][FIX]-account_operating_unit: fix the error 'You are trying to …

### DIFF
--- a/account_operating_unit/readme/CONTRIBUTORS.rst
+++ b/account_operating_unit/readme/CONTRIBUTORS.rst
@@ -8,3 +8,4 @@
 * Alan Ramos <alan.ramos@jarsa.com.mx>
 * Saran Lim. <saranl@ecosoft.co.th>
 * Pimolnat Suntian <pimolnats@ecosoft.co.th>
+* Hieu, Vo Minh Bao <hieu.vmb@komit-consulting.com>

--- a/account_operating_unit/wizards/account_payment_register.py
+++ b/account_operating_unit/wizards/account_payment_register.py
@@ -24,7 +24,7 @@ class AccountPaymentRegister(models.TransientModel):
                     )
                 )
             if reconciled_moves.operating_unit_id != payment.operating_unit_id:
-                destination_account = payments.destination_account_id
+                destination_account = payment.destination_account_id
                 to_reconcile |= payment.move_id.line_ids.filtered(
                     lambda l: l.account_id == destination_account
                 )
@@ -41,5 +41,5 @@ class AccountPaymentRegister(models.TransientModel):
                     }
                 )
                 payment.action_post()
-                to_reconcile.reconcile()
+                to_reconcile.filtered(lambda r: not r.reconciled).reconcile()
         return payments


### PR DESCRIPTION
[FIX] account_operating_unit: fix the error 'You are trying to reconcile some entries that are already reconciled'

"You are trying to reconcile some entries that are already reconciled"
How to reproduce the issue:

    1. Use Payment Term on Invoice, so Payable / Receivable Journal Item Line will be split to 2 lines.
    2. Register Payment to pay the first Payable / Receivable Journal Item Line.
    3. Second Register Payment will face the error above.

<img width="1461" alt="image" src="https://user-images.githubusercontent.com/12895874/213088513-15c1bf53-619b-47f2-a501-1067c477fc49.png">

