### PR TITLE
[15.0][FIX] analytic operating unit: domain ou in users

### DIFF
--- a/analytic_operating_unit/models/account_analytic_account.py
+++ b/analytic_operating_unit/models/account_analytic_account.py
@@ -11,7 +11,6 @@ class AccountAnalyticAccount(models.Model):
         comodel_name="operating.unit",
         string="Operating Units",
         relation="analytic_account_operating_unit_rel",
-        domain="[('user_ids', '=', uid)]",
         column1="analytic_account_id",
         column2="operating_unit_id",
     )


### PR DESCRIPTION
[BUG]
user (multi ou) can't see other ou in analytic
![1](https://user-images.githubusercontent.com/20896369/214256393-32c9c134-89fc-4b3d-b0c4-fb1850d838e3.gif)

This pr fix domain in analytic can select other ou in analytic
![2](https://user-images.githubusercontent.com/20896369/214257039-a1047d2d-7efa-4643-aae6-c5730a42e5fa.gif)
