### PR TITLE
[FIX] 14.0 sale_operating_unit Error sale report to add fiel operating unit

### DIFF
--- a/sale_operating_unit/README.rst
+++ b/sale_operating_unit/README.rst
@@ -23,7 +23,7 @@ Operating Unit in Sales
     :target: https://runbot.odoo-community.org/runbot/213/14.0
     :alt: Try me on Runbot
 
-|badge1| |badge2| |badge3| |badge4| |badge5| 
+|badge1| |badge2| |badge3| |badge4| |badge5|
 
 This module extends the Sales capabilities of Odoo and introduces the operating
 unit to the Sales Order. Security rules are defined to ensure that users can
@@ -81,6 +81,7 @@ Contributors
 * Darshan Patel <darshan.patel.serpencs@gmail.com>
 * Alan Ramos <alan.ramos@jarsa.com.mx>
 * Jorge Alberto Olvera Cuenca <jorge.olvera@jarsa.com>
+* Carlos Ramos - <cramosh@dmintegrations.eu>
 
 Maintainers
 ~~~~~~~~~~~

--- a/sale_operating_unit/report/sale_report.py
+++ b/sale_operating_unit/report/sale_report.py
@@ -1,17 +1,19 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
+# Copyright 2022 Dm Integrations - Carlos Ramos
 
 from odoo import fields, models
 
 
 class SaleReport(models.Model):
-
     _inherit = "sale.report"
 
     operating_unit_id = fields.Many2one("operating.unit", "Operating Unit")
 
-    def _query(self, with_clause="", fields=False, groupby="", from_clause=""):  # noqa
-        if not fields:
-            fields = {}
+    def _group_by_sale(self, groupby=""):
+        res = super()._group_by_sale(groupby)
+        res += """, s.operating_unit_id"""
+        return res
+
+    def _select_additional_fields(self, fields):
         fields["operating_unit_id"] = ", s.operating_unit_id as operating_unit_id"
-        groupby += ", s.operating_unit_id"
-        return super(SaleReport, self)._query(with_clause, fields, groupby, from_clause)
+        return super()._select_additional_fields(fields)

--- a/sale_operating_unit/report/sale_report.py
+++ b/sale_operating_unit/report/sale_report.py
@@ -1,5 +1,4 @@
 # License LGPL-3.0 or later (http://www.gnu.org/licenses/lgpl-3.0).
-# Copyright 2022 Dm Integrations - Carlos Ramos
 
 from odoo import fields, models
 


### PR DESCRIPTION
This PR solves the error that the sale report has when adding the sale_operating_unit field after the odoo update