### PR TITLE
[15.0][FIX] stock_operating_unit: filter domain users out

### DIFF
--- a/stock_operating_unit/model/stock_location.py
+++ b/stock_operating_unit/model/stock_location.py
@@ -8,7 +8,10 @@ from odoo.exceptions import UserError
 class StockLocation(models.Model):
     _inherit = "stock.location"
 
-    operating_unit_id = fields.Many2one("operating.unit", "Operating Unit")
+    operating_unit_id = fields.Many2one(
+        comodel_name="operating.unit",
+        string="Operating Unit",
+    )
 
     @api.constrains("operating_unit_id")
     def _check_warehouse_operating_unit(self):

--- a/stock_operating_unit/model/stock_picking.py
+++ b/stock_operating_unit/model/stock_picking.py
@@ -9,8 +9,8 @@ class StockPicking(models.Model):
     _inherit = "stock.picking"
 
     operating_unit_id = fields.Many2one(
-        "operating.unit",
-        "Requesting Operating Unit",
+        comodel_name="operating.unit",
+        string="Requesting Operating Unit",
         readonly=True,
         states={"draft": [("readonly", False)]},
     )

--- a/stock_operating_unit/model/stock_rule.py
+++ b/stock_operating_unit/model/stock_rule.py
@@ -9,7 +9,6 @@ class StockRule(models.Model):
     _inherit = "stock.rule"
 
     operating_unit_id = fields.Many2one(
-        "operating.unit",
+        comodel_name="operating.unit",
         related="warehouse_id.operating_unit_id",
-        domain="[('user_ids', '=', uid)]",
     )

--- a/stock_operating_unit/view/stock.xml
+++ b/stock_operating_unit/view/stock.xml
@@ -12,8 +12,7 @@
                 <field
                     name="operating_unit_id"
                     options="{'no_create': True}"
-                    domain="[('company_id','=', company_id),
-                       ('user_ids', 'in', uid)]"
+                    domain="[('company_id','=', company_id)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -27,7 +26,6 @@
             <field name="partner_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -42,8 +40,7 @@
                 <field
                     name="operating_unit_id"
                     options="{'no_create': True}"
-                    domain="[('company_id','=', company_id),
-                       ('user_ids', 'in', uid)]"
+                    domain="[('company_id','=', company_id)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -57,7 +54,6 @@
             <field name="usage" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -71,7 +67,6 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -85,7 +80,6 @@
             <field name="origin" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -103,8 +97,7 @@
                 <field
                     name="operating_unit_id"
                     options="{'no_create': True}"
-                    domain="[('company_id','=', company_id),
-                       ('user_ids', 'in', uid)]"
+                    domain="[('company_id','=', company_id)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </xpath>
@@ -123,7 +116,6 @@
             <field name="product_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -145,14 +137,12 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
             <field name="location_dest_id" position="after">
                 <field
                     name="operating_unit_dest_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -166,14 +156,12 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
             <field name="location_dest_id" position="after">
                 <field
                     name="operating_unit_dest_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -187,14 +175,12 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
             <field name="location_dest_id" position="after">
                 <field
                     name="operating_unit_dest_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -208,14 +194,12 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
             <field name="location_dest_id" position="after">
                 <field
                     name="operating_unit_dest_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>


### PR DESCRIPTION
BUG:
Field `operating_unit_id` in stock can see 1 OU only. This PR is filter domain users out for see OU following all your operating unit