### PR TITLE
[15.0][FIX] stock_operating_unit: remove domain of operation type

### DIFF
--- a/stock_operating_unit/view/stock.xml
+++ b/stock_operating_unit/view/stock.xml
@@ -101,11 +101,6 @@
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </xpath>
-            <field name="picking_type_id" position="attributes">
-                <attribute
-                    name="domain"
-                >[('warehouse_id.operating_unit_id.user_ids', 'in', uid)]</attribute>
-            </field>
         </field>
     </record>
     <record id="view_picking_internal_search" model="ir.ui.view">


### PR DESCRIPTION
Remove the domain of **Operation Type** because users with multi-operating units cannot select other the operation type except the operation type of the default operating unit

**Before :**
![Screenshot from 2023-03-09 17-14-04](https://user-images.githubusercontent.com/51266019/223991475-4a1f6670-42a1-4c27-94ac-899df8e17ef3.png)

**After :**
![Screenshot from 2023-03-09 17-11-33](https://user-images.githubusercontent.com/51266019/223990473-662cce9c-bfeb-42c5-a692-0a7224ec0e2c.png)
