### PR TITLE
[15.0][FIX] account_operating_unit: add OU to tree view of account.move.line

### DIFF
--- a/account_operating_unit/views/account_move_view.xml
+++ b/account_operating_unit/views/account_move_view.xml
@@ -32,6 +32,21 @@
             </xpath>
         </field>
     </record>
+    <record id="view_move_line_tree_grouped" model="ir.ui.view">
+        <field name="name">account.move.line.tree.grouped</field>
+        <field name="model">account.move.line</field>
+        <field name="inherit_id" ref="account.view_move_line_tree_grouped" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='account_id']" position="after">
+                <field
+                    name="operating_unit_id"
+                    options="{'no_create': True}"
+                    optional="show"
+                    groups="operating_unit.group_multi_operating_unit"
+                />
+            </xpath>
+        </field>
+    </record>
     <record id="view_account_move_line_filter" model="ir.ui.view">
         <field name="name">Journal Items</field>
         <field name="model">account.move.line</field>


### PR DESCRIPTION
I add OU to the tree view of `account.move.line`.

`view_move_line_tree_grouped` has higher priority than `view_move_line_tree`.
So, when you want to show a tree view of `account.move.line` by default is used `view_move_line_tree_grouped`.