### PR TITLE
[15.0][FIX] account_operating_unit: split function for support expense operating unit

### DIFF
--- a/account_operating_unit/wizards/account_payment_register.py
+++ b/account_operating_unit/wizards/account_payment_register.py
@@ -8,15 +8,16 @@ from odoo.exceptions import UserError
 class AccountPaymentRegister(models.TransientModel):
     _inherit = "account.payment.register"
 
+    def _get_reconciled_moves(self, payment):
+        return payment.reconciled_bill_ids + payment.reconciled_invoice_ids
+
     def _create_payments(self):
         payments = super()._create_payments()
         if self.group_payment and len(payments) > 1:
             return payments
         for payment in payments:
             to_reconcile = self.env["account.move.line"]
-            reconciled_moves = (
-                payment.reconciled_bill_ids + payment.reconciled_invoice_ids
-            )
+            reconciled_moves = self._get_reconciled_moves(payment)
             if len(reconciled_moves.operating_unit_id) > 1:
                 raise UserError(
                     _(


### PR DESCRIPTION
Bug:
Expense can't register payment when we config self-balance. it will error 
"Configuration error. The operating unit is mandatory for each line as the operating unit has been defined as self-balanced at company level."

it because this module get `reconciled_moves` from `payment.reconciled_bill_ids + payment.reconciled_invoice_ids` (payment from expense don't have bills)

This PR is split function for expense_operating_unit hook and change it to move on expense