### PR TITLE
[15.0][IMP] account_operating_unit: add OU in move line outstanding payment

### DIFF
--- a/account_operating_unit/models/account_payment.py
+++ b/account_operating_unit/models/account_payment.py
@@ -31,8 +31,13 @@ class AccountPayment(models.Model):
         )
         invoices_ou = invoices.operating_unit_id
         if invoices and len(invoices_ou) == 1 and invoices_ou != self.operating_unit_id:
+            self_balanced = self.env.company.ou_is_self_balanced
             destination_account_id = self.destination_account_id.id
             for line in lines:
-                if line["account_id"] == destination_account_id:
+                if (
+                    not self_balanced
+                    and not line.get("operating_unit_id", False)
+                    or (line["account_id"] == destination_account_id)
+                ):
                     line["operating_unit_id"] = invoices_ou.id
         return lines


### PR DESCRIPTION
Step to test:
1. Create vendor bills > confirm > register payment (register payment with journal is not set operating unit)
2. JE will not add OU in Outstanding Payment
![Selection_003](https://user-images.githubusercontent.com/20896369/228819454-f448f8dd-5c7c-4c35-aa34-058e53dbe3c5.png)

This PR is add OU following:
- self-balanced and set operating unit in journal = Outstanding Payment will add OU journal
- self-balanced and not set operating unit in journal = Error
- Not self-balanced and set operating unit in journal = Outstanding Payment will add OU journal
- Not self-balanced and Not operating unit in journal = Outstanding Payment will add OU from invoices

