### PR TITLE
[15.0][FIX] stock_operating_unit: migration script to 15.0

### DIFF
--- a/stock_operating_unit/migrations/15.0.1.0.0/pre-migration.py
+++ b/stock_operating_unit/migrations/15.0.1.0.0/pre-migration.py
@@ -11,6 +11,6 @@ def migrate(cr, installed_version):
         UPDATE stock_quant
         SET operating_unit_id = sl.operating_unit_id
         FROM stock_location sl
-        WHERE sl.id=location_id AND sl.operating_unit_id IS NOT NULL;
+        WHERE sl.id=stock_quant.location_id AND sl.operating_unit_id IS NOT NULL;
     """
     )


### PR DESCRIPTION
Solves this issue:

```
2023-05-23 07:40:10,881 1 INFO mydb odoo.modules.migration: module stock_operating_unit: Running migration [>15.0.1.0.0] pre-migration 
2023-05-23 07:40:10,882 1 ERROR mydb odoo.sql_db: bad query: 
        UPDATE stock_quant
        SET operating_unit_id = sl.operating_unit_id
        FROM stock_location sl
        WHERE sl.id=location_id AND sl.operating_unit_id IS NOT NULL;
    
ERROR: column reference "location_id" is ambiguous
LINE 5:         WHERE sl.id=location_id AND sl.operating_unit_id IS ...
```
