### PR TITLE
[15.0][FIX] purchase_request_operating_unit: operating unit when purchase request is created based on procurements

### DIFF
--- a/purchase_request_operating_unit/model/__init__.py
+++ b/purchase_request_operating_unit/model/__init__.py
@@ -1,3 +1,4 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
 from . import purchase_request
+from . import stock_rule

--- a/purchase_request_operating_unit/model/purchase_request.py
+++ b/purchase_request_operating_unit/model/purchase_request.py
@@ -53,7 +53,7 @@ class PurchaseRequest(models.Model):
                 ):
                     raise ValidationError(
                         _(
-                            "Configuration error. The Purchase Request and the"
+                            "Configuration error. The Purchase Request and the "
                             "Warehouse of picking type must belong to the same "
                             "Operating Unit."
                         )

--- a/purchase_request_operating_unit/model/stock_rule.py
+++ b/purchase_request_operating_unit/model/stock_rule.py
@@ -1,0 +1,15 @@
+# Copyright 2023 ForgeFlow, S.L.
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl-3.0)
+
+from odoo import api, models
+
+
+class StockRule(models.Model):
+    _inherit = "stock.rule"
+
+    @api.model
+    def _prepare_purchase_request(self, origin, values):
+        res = super(StockRule, self)._prepare_purchase_request(origin, values)
+        if self.warehouse_id.operating_unit_id:
+            res.update({"operating_unit_id": self.warehouse_id.operating_unit_id.id})
+        return res


### PR DESCRIPTION
Enable the route MTO or dropship in a product. Then try to create a sales order for that product in another operating unit than the main operating unit. This constraint will raise: https://github.com/OCA/operating-unit/blob/15.0/purchase_request_operating_unit/model/purchase_request.py#L56, because it will try to create the purcahse request for the main operating unit, instead the operating unit of the procurement, which is the operating unit of the sales order. 

cc @ForgeFlow @BT-pcavero 