### PR TITLE
[15.0][FIX] sale_operating_unit: permission update OU in invoices

### DIFF
--- a/sale_operating_unit/wizard/sale_make_invoice_advance.py
+++ b/sale_operating_unit/wizard/sale_make_invoice_advance.py
@@ -8,5 +8,5 @@ class SaleAdvancePaymentInv(models.TransientModel):
         invoice = super(SaleAdvancePaymentInv, self)._create_invoice(
             order, so_line, amount
         )
-        invoice.operating_unit_id = order.operating_unit_id.id
+        invoice.sudo().write({"operating_unit_id": order.operating_unit_id.id})
         return invoice


### PR DESCRIPTION
Step to error
1. Create user permission 'User: Own Documents Only'
2. login user sale and create sale order
3. when sale create invoice and select not `Regular invoice` (after create product already), it will error permission
![Selection_012](https://github.com/OCA/operating-unit/assets/20896369/ad089cd9-4bc2-4e5f-8f3a-8186cd5a2bf8)

![Selection_011](https://github.com/OCA/operating-unit/assets/20896369/ea57e71a-6e7b-41e4-8807-5fcc8275c1cd)

Sale don't allow to write field in invoice. I add sudo() for write OU in invoice