### PR TITLE
[FIX] product_operating_unit: get_default_category(): object

### DIFF
--- a/product_operating_unit/models/product_template.py
+++ b/product_operating_unit/models/product_template.py
@@ -64,7 +64,7 @@ class ProductTemplate(models.Model):
             _logger.info("%s" % (ou_id.name))
             category = self.env["product.category"].search([], limit=1)
             if category:
-                return category.id
+                return category
             else:
                 try:
                     self.env.ref(


### PR DESCRIPTION
Fix Issue #602 
The default recordset object is returned from _get_default_category_id()
