### PR TITLE
[13.0][IMP] account_operating_unit: added migration scripts

### DIFF
--- a/account_operating_unit/migrations/13.0.1.0.0/post-migration.py
+++ b/account_operating_unit/migrations/13.0.1.0.0/post-migration.py
@@ -1,0 +1,28 @@
+from openupgradelib import openupgrade
+
+
+def fill_account_move_operating_unit(env):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move_line aml
+        SET operating_unit_id = ail.operating_unit_id
+        FROM account_invoice_line ail
+        WHERE aml.old_invoice_line_id = ail.id
+        AND aml.operating_unit_id is NULL""",
+    )
+
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move am
+        SET operating_unit_id = ai.operating_unit_id
+        FROM account_invoice ai
+        WHERE am.old_invoice_id = ai.id
+        AND am.operating_unit_id is NULL""",
+    )
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    fill_account_move_operating_unit(env)


### PR DESCRIPTION
Operating units should be passed from invoices when migrating. This assumes the database was migrated using OpenUpgrade

@ForgeFlow @MiquelRForgeFlow 