### PR TITLE
[15.0][FIX] account_operating_unit: assign operating unit of the invoice journal has no operating unit no matter if OU are self balanced

### DIFF
--- a/account_operating_unit/models/account_payment.py
+++ b/account_operating_unit/models/account_payment.py
@@ -31,13 +31,10 @@ class AccountPayment(models.Model):
         )
         invoices_ou = invoices.operating_unit_id
         if invoices and len(invoices_ou) == 1 and invoices_ou != self.operating_unit_id:
-            self_balanced = self.env.company.ou_is_self_balanced
             destination_account_id = self.destination_account_id.id
             for line in lines:
-                if (
-                    not self_balanced
-                    and not line.get("operating_unit_id", False)
-                    or (line["account_id"] == destination_account_id)
+                if not line.get("operating_unit_id", False) or (
+                    line["account_id"] == destination_account_id
                 ):
                     line["operating_unit_id"] = invoices_ou.id
         return lines


### PR DESCRIPTION
In this fix https://github.com/OCA/operating-unit/pull/582 the following criteria was implemented in regards operating units for payments:

- self-balanced and set operating unit in journal = Outstanding Payment will add OU journal
- self-balanced and not set operating unit in journal = Error
- Not self-balanced and set operating unit in journal = Outstanding Payment will add OU journal
- Not self-balanced and Not operating unit in journal = Outstanding Payment will add OU from invoices

After some testing, I thing the second criteria should not trigger an error. We should add the OU from invoices in the case OU are balanced and not operating unit in the journal. In previous versions it was possible to have a OU that is self-balanced and journals without operating unit, and the journal items for the payment had the operating unit of the invoice in that case.

@ForgeFlow 