### PR TITLE
[15.0][FIX] account_operating_unit: domain analytic from operating unit line

### DIFF
--- a/account_operating_unit/views/account_move_view.xml
+++ b/account_operating_unit/views/account_move_view.xml
@@ -138,18 +138,7 @@
             >
                 <attribute name="domain">
                     ['|', ('company_id', '=', parent.company_id), ('company_id', '=',
-                    False), '|', ('operating_unit_ids', '=',
-                    context.get('default_operating_unit_id', False)),
-                    ('operating_unit_ids', '=', False)]
-                </attribute>
-            </xpath>
-            <xpath
-                expr="//field[@name='line_ids']/form/group/field[@name='analytic_account_id']"
-                position="attributes"
-            >
-                <attribute name="domain">
-                    ['|', ('operating_unit_ids', '=',
-                    context.get('default_operating_unit_id', False)),
+                    False), '|', ('operating_unit_ids', '=', operating_unit_id),
                     ('operating_unit_ids', '=', False)]
                 </attribute>
             </xpath>


### PR DESCRIPTION
Step to error:
1. Create Journal Entries
2. In header not select operating unit
3. Add a line with OU1
4. It will invisible analytic with OU1

![Selection_005](https://github.com/OCA/operating-unit/assets/20896369/054787e8-2592-4224-ac29-d0a378b08e1b)

Analytic Account has 2 OU but can't selected
![Selection_006](https://github.com/OCA/operating-unit/assets/20896369/39c8ac2b-ea1a-4574-b0d4-a6b19151c13a)
