### PR TITLE
[15.0][FIX] stock_operating_unit: access to picking types when warehouse is not set

### DIFF
--- a/stock_operating_unit/security/stock_security.xml
+++ b/stock_operating_unit/security/stock_security.xml
@@ -19,6 +19,8 @@
     <record id="ir_rule_stock_picking_type_allowed_operating_units" model="ir.rule">
         <field name="model_id" ref="stock.model_stock_picking_type" />
         <field name="domain_force">['|',
+            ('warehouse_id','=',False),
+            '|',
             ('warehouse_id.operating_unit_id','=', False),
             ('warehouse_id.operating_unit_id','in',user.operating_unit_ids.ids)]
         </field>


### PR DESCRIPTION
For example, the default dropship rule created by odoo has no warehouse. Users are getting errors when accessing dropship purchase orders.