### PR TITLE
[14.0][ENH] purchase_operating_unit: add OU to Purchase Analysis Report

### DIFF
--- a/purchase_operating_unit/__manifest__.py
+++ b/purchase_operating_unit/__manifest__.py
@@ -17,6 +17,7 @@
     "license": "LGPL-3",
     "data": [
         "security/purchase_security.xml",
+        "report/purchase_report_view.xml",
         "views/purchase_order_view.xml",
         "views/purchase_order_line_view.xml",
     ],

--- a/purchase_operating_unit/report/__init__.py
+++ b/purchase_operating_unit/report/__init__.py
@@ -1,3 +1,2 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from . import models
-from . import report
+from . import purchase_report

--- a/purchase_operating_unit/report/purchase_report.py
+++ b/purchase_operating_unit/report/purchase_report.py
@@ -1,0 +1,24 @@
+# Copyright 2023 Ecosoft Co., Ltd (http://ecosoft.co.th/)
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo import fields, models
+
+
+class PurchaseReport(models.Model):
+    _inherit = "purchase.report"
+
+    operating_unit_id = fields.Many2one(
+        comodel_name="operating.unit",
+        string="Operating Unit",
+        readonly=True,
+    )
+
+    def _select(self):
+        select_str = super()._select()
+        select_str += """, po.operating_unit_id"""
+        return select_str
+
+    def _group_by(self):
+        group_by_str = super()._group_by()
+        group_by_str += """, po.operating_unit_id"""
+        return group_by_str

--- a/purchase_operating_unit/report/purchase_report_view.xml
+++ b/purchase_operating_unit/report/purchase_report_view.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" ?>
+<odoo>
+    <record id="view_purchase_order_search" model="ir.ui.view">
+        <field name="name">report.purchase.order.search</field>
+        <field name="model">purchase.report</field>
+        <field name="inherit_id" ref="purchase.view_purchase_order_search" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field
+                    name="operating_unit_id"
+                    groups="operating_unit.group_multi_operating_unit"
+                />
+            </xpath>
+            <xpath expr="//filter[@name='company']" position="after">
+                <filter
+                    string="Operating Unit"
+                    name="group_operating_unit_id"
+                    context="{'group_by': 'operating_unit_id'}"
+                    groups="operating_unit.group_multi_operating_unit"
+                />
+            </xpath>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
Add operating unit to `purchase.report`

![purchase_report](https://github.com/OCA/operating-unit/assets/51266019/3eeed586-9ee3-49af-9a77-84c210821194)

