### PR TITLE
[16.0][FW][FIX] operating_unit: default operating unit more multi-company friendly

### DIFF
--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -14,7 +14,19 @@ class ResUsers(models.Model):
         if not uid2:
             uid2 = self.env.user.id
         user = self.env["res.users"].browse(uid2)
-        return user.default_operating_unit_id
+        # check if the company of the default OU is active
+        if user.default_operating_unit_id.sudo().company_id in self.env.companies:
+            return user.default_operating_unit_id
+        else:
+            # find an OU of the main active company
+            for ou in user.assigned_operating_unit_ids:
+                if ou.sudo().company_id in self.env.company:
+                    return ou
+            # find an OU of any active company
+            for ou in user.assigned_operating_unit_ids:
+                if ou.sudo().company_id in self.env.companies:
+                    return ou
+        return False
 
     @api.model
     def _default_operating_unit(self):

--- a/product_operating_unit/models/product_template.py
+++ b/product_operating_unit/models/product_template.py
@@ -19,12 +19,13 @@ class ProductTemplate(models.Model):
     def _default_operating_unit_ids(self):
         if self.categ_id and self.categ_id.operating_unit_ids:
             return [(6, 0, self.categ_id.operating_unit_ids.ids)]
-        if self.env.user.default_operating_unit_id:
+        default_ou = self.env["res.users"].operating_unit_default_get(self.env.uid)
+        if default_ou:
             return [
                 (
                     6,
                     0,
-                    [self.env["res.users"].operating_unit_default_get(self.env.uid).id],
+                    default_ou.ids,
                 )
             ]
 


### PR DESCRIPTION
FW of #642 

This PR fixes an issue with the method operating_unit_default_get where it would return an operating unit even for a company that was not active, which would cause all sorts of issues

Steps to reproduce on runboat,
taking as example purchase_operating_unit:

- User has a default ou belonging to Company 1
- Switch to Company 2 (make sure Company 1 is not active at all)
- Try to create a Purchase Order

The issue arises because the operating_unit field is pre-compiled on the PO with an Operating Unit whose company is inactive, and the onchanges cannot find or access related data.