### PR TITLE
[14.0][FIX] purchase_operating_unit: default picking_type without OU

### DIFF
--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -14,14 +14,15 @@ class PurchaseOrder(models.Model):
         res = super(PurchaseOrder, self)._default_picking_type()
         type_obj = self.env["stock.picking.type"]
         operating_unit = self.env["res.users"].operating_unit_default_get(self.env.uid)
-        types = type_obj.search(
-            [
-                ("code", "=", "incoming"),
-                ("warehouse_id.operating_unit_id", "=", operating_unit.id),
-            ]
-        )
-        if types:
-            res = types[:1].id
+        if operating_unit:
+            types = type_obj.search(
+                [
+                    ("code", "=", "incoming"),
+                    ("warehouse_id.operating_unit_id", "=", operating_unit.id),
+                ]
+            )
+            if types:
+                res = types[:1].id
         return res
 
     READONLY_STATES = {


### PR DESCRIPTION
Fixes an issue when creating a PO, if the user doesn't have any operating units assigned.