### PR TITLE
[15.0][FIX] purchase_request_operating_unit: respect original domain

### DIFF
--- a/purchase_request_operating_unit/wizard/purchase_request_line_make_purchase_order_view.xml
+++ b/purchase_request_operating_unit/wizard/purchase_request_line_make_purchase_order_view.xml
@@ -23,7 +23,7 @@
             <field name="purchase_order_id" position="attributes">
                 <attribute
                     name="domain"
-                >['|', ('operating_unit_id', '=', False), ('operating_unit_id', '=', operating_unit_id)]</attribute>
+                >['&amp;', ('partner_id', '=', supplier_id), '|', ('operating_unit_id', '=', False), ('operating_unit_id', '=', operating_unit_id)]</attribute>
             </field>
         </field>
     </record>


### PR DESCRIPTION
purchase_request_operating_unit: respect original domain in purchase_id in wizard to create RFQ from purchase request line:

https://github.com/OCA/purchase-workflow/blob/16.0/purchase_request/wizard/purchase_request_line_make_purchase_order_view.xml#L16

currently it's been overwritten


cc @ForgeFlow