### PR TITLE
[15.0][FIX] hr_payroll_account_operating_unit: assign the operating unit to the payslip journal items

### DIFF
--- a/hr_payroll_account_operating_unit/models/hr_payslip.py
+++ b/hr_payroll_account_operating_unit/models/hr_payslip.py
@@ -22,3 +22,73 @@ class HrPayslip(models.Model):
                             {"operating_unit_id": slip.operating_unit_id.id}
                         )
         return res
+
+    def _prepare_debit_line(
+        self,
+        line,
+        slip,
+        amount,
+        date,
+        debit_account_id,
+        analytic_salary_id,
+        tax_ids,
+        tax_tag_ids,
+        tax_repartition_line_id,
+    ):
+        res = super()._prepare_debit_line(
+            line,
+            slip,
+            amount,
+            date,
+            debit_account_id,
+            analytic_salary_id,
+            tax_ids,
+            tax_tag_ids,
+            tax_repartition_line_id,
+        )
+        res.update(operating_unit_id=slip.operating_unit_id.id)
+        return res
+
+    def _prepare_credit_line(
+        self,
+        line,
+        slip,
+        amount,
+        date,
+        credit_account_id,
+        analytic_salary_id,
+        tax_ids,
+        tax_tag_ids,
+        tax_repartition_line_id,
+    ):
+        res = super()._prepare_credit_line(
+            line,
+            slip,
+            amount,
+            date,
+            credit_account_id,
+            analytic_salary_id,
+            tax_ids,
+            tax_tag_ids,
+            tax_repartition_line_id,
+        )
+        res.update(operating_unit_id=slip.operating_unit_id.id)
+        return res
+
+    def _prepare_adjust_credit_line(
+        self, currency, credit_sum, debit_sum, journal, date
+    ):
+        res = super()._prepare_adjust_credit_line(
+            currency, credit_sum, debit_sum, journal, date
+        )
+        res.update(operating_unit_id=self.operating_unit_id.id)
+        return res
+
+    def _prepare_adjust_debit_line(
+        self, currency, credit_sum, debit_sum, journal, date
+    ):
+        res = super()._prepare_adjust_debit_line(
+            currency, credit_sum, debit_sum, journal, date
+        )
+        res.update(operating_unit_id=self.operating_unit_id.id)
+        return res


### PR DESCRIPTION
Assign the operating unit to the payslip journal items. Doing it in the write method is not sufficient when the journal item is created before. And the constraint here is raised: 

https://github.com/OCA/operating-unit/blob/15.0/account_operating_unit/models/account_move.py#L205

This depends on https://github.com/OCA/payroll/pull/146

cc @ForgeFlow