### PR TITLE
[14.0] Replace 'Camptocamp SA' with 'Camptocamp'

### DIFF
--- a/mis_builder_budget_operating_unit/__manifest__.py
+++ b/mis_builder_budget_operating_unit/__manifest__.py
@@ -4,7 +4,7 @@
     "name": "MIS Builder Budget with Operating Unit",
     "version": "14.0.1.0.0",
     "category": "Reporting",
-    "author": "Camptocamp SA,Odoo Community Association (OCA)",
+    "author": "Camptocamp,Odoo Community Association (OCA)",
     "license": "AGPL-3",
     "website": "https://github.com/OCA/operating-unit",
     "depends": ["mis_builder_budget", "operating_unit"],


### PR DESCRIPTION
This pull request contains changes to replace 'Camptocamp SA' with 'Camptocamp' in __manifest__.py files for branch 14.0.