### PR TITLE
[15.0][FIX] account_operating_unit: add operating unit to cash basis counterpart base line

### DIFF
--- a/account_operating_unit/models/account_partial_reconcile.py
+++ b/account_operating_unit/models/account_partial_reconcile.py
@@ -16,6 +16,12 @@ class AccountPartialReconcile(models.Model):
         return res
 
     @api.model
+    def _prepare_cash_basis_counterpart_base_line_vals(self, cb_base_line_vals):
+        res = super()._prepare_cash_basis_counterpart_base_line_vals(cb_base_line_vals)
+        res.update({"operating_unit_id": cb_base_line_vals.get("operating_unit_id")})
+        return res
+
+    @api.model
     def _prepare_cash_basis_tax_line_vals(self, tax_line, balance, amount_currency):
         res = super()._prepare_cash_basis_tax_line_vals(
             tax_line, balance, amount_currency


### PR DESCRIPTION
This commit adds the operating unit to the cash basis counterpart base line when cash basis accounting is enabled.