### PR TITLE
[15.0][FIX] account_operating_unit: do not show inter-OU balance journals as invoice lines

### DIFF
--- a/account_operating_unit/__manifest__.py
+++ b/account_operating_unit/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Accounting with Operating Units",
     "summary": "Introduces Operating Unit (OU) in invoices and "
     "Accounting Entries with clearing account",
-    "version": "15.0.1.2.3",
+    "version": "15.0.1.3.0",
     "author": "ForgeFlow, "
     "Serpent Consulting Services Pvt. Ltd.,"
     "WilldooIT Pty Ltd,"

--- a/account_operating_unit/migrations/15.0.1.3.0/pre-migration.py
+++ b/account_operating_unit/migrations/15.0.1.3.0/pre-migration.py
@@ -1,0 +1,31 @@
+# Copyright 2024 ForgeFlow S.L.  <https://www.forgeflow.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    if not openupgrade.column_exists(env.cr, "account_move_line", "is_ou_balance"):
+        openupgrade.logged_query(
+            env.cr,
+            """
+            ALTER TABLE account_move_line
+            ADD COLUMN IF NOT EXISTS is_ou_balance BOOLEAN DEFAULT false
+            """,
+        )
+        openupgrade.logged_query(
+            env.cr,
+            """ALTER TABLE account_move_line ALTER COLUMN is_ou_balance DROP DEFAULT""",
+        )
+        openupgrade.logged_query(
+            env.cr,
+            """
+            UPDATE account_move_line aml0 SET is_ou_balance = true
+            FROM account_move_line aml
+            INNER JOIN res_company rc ON rc.id = aml.company_id
+            WHERE aml.name = 'OU-Balancing'
+            AND aml.account_id = rc.inter_ou_clearing_account_id
+            AND rc.ou_is_self_balanced = true
+            AND aml0.id = aml.id
+        """,
+        )

--- a/account_operating_unit/static/description/index.html
+++ b/account_operating_unit/static/description/index.html
@@ -8,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -274,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -300,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -487,7 +488,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
Please do merge without bumping the version number

Fixes: https://github.com/OCA/operating-unit/issues/617

I am not sure about adding a new boolean for this purpose:

- Normally companies won't allow setting posting entries back to draft
- The use case is not common, so adding a new column in a big table may not be good

We can delete the journal items by filtering the ones with name "OU-Balancing" or ref "Inter OU Balancing", but that criteria is not exact as long that reference could be added manually by the user, and the system will be deleting those journal items incorrectly.

@ForgeFlow