### PR TITLE
[17.0][FIX] res_partner_operating_unit: Fix error when create new user

### DIFF
--- a/res_partner_operating_unit/models/res_users.py
+++ b/res_partner_operating_unit/models/res_users.py
@@ -14,6 +14,9 @@ class ResUsers(models.Model):
         users = super().create(vals_list)
         for user in users:
             user_ou = user.default_operating_unit_id or user._default_operating_unit()
+            if not user_ou:
+                user.check_partner_operating_unit()
+                continue
             user.partner_id.operating_unit_ids = [Command.link(user_ou.id)]
             user.check_partner_operating_unit()
         return users

--- a/res_partner_operating_unit/static/description/index.html
+++ b/res_partner_operating_unit/static/description/index.html
@@ -8,11 +8,10 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
+:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
-Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +274,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: gray; } /* line numbers */
+pre.code .ln { color: grey; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +300,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic, pre.problematic {
+span.problematic {
   color: red }
 
 span.section-subtitle {
@@ -439,9 +438,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-7">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org">
-<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
-</a>
+<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>


### PR DESCRIPTION
When register new user, if the user not have any `default_operating_unit_id`, show this error.
![image](https://github.com/user-attachments/assets/7d1eaba7-7bbc-44f8-9b80-f4159da27670)


To fix it, I add new condition for check `user_ou` has value.
