### PR TITLE
[16.0][FIX] account_operating_unit: do not show inter-OU balance journals as invoice lines

### DIFF
--- a/account_operating_unit/__manifest__.py
+++ b/account_operating_unit/__manifest__.py
@@ -5,7 +5,7 @@
     "name": "Accounting with Operating Units",
     "summary": "Introduces Operating Unit (OU) in invoices and "
     "Accounting Entries with clearing account",
-    "version": "16.0.1.0.0",
+    "version": "16.0.1.1.0",
     "author": "ForgeFlow, "
     "Serpent Consulting Services Pvt. Ltd.,"
     "WilldooIT Pty Ltd,"

--- a/account_operating_unit/migrations/16.0.1.1.0/pre-migration.py
+++ b/account_operating_unit/migrations/16.0.1.1.0/pre-migration.py
@@ -1,0 +1,19 @@
+# Copyright 2024 ForgeFlow S.L.  <https://www.forgeflow.com>
+# License LGPL-3.0 or later (http://www.gnu.org/licenses/agpl.html).
+from openupgradelib import openupgrade
+
+
+@openupgrade.migrate()
+def migrate(env, version):
+    openupgrade.logged_query(
+        env.cr,
+        """
+        UPDATE account_move_line aml0 SET display_type = 'ou_balance'
+        FROM account_move_line aml
+        INNER JOIN res_company rc ON rc.id = aml.company_id
+        WHERE aml.name = 'OU-Balancing'
+        AND aml.account_id = rc.inter_ou_clearing_account_id
+        AND rc.ou_is_self_balanced = true
+        AND aml0.id = aml.id
+    """,
+    )

--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -74,6 +74,7 @@ class AccountMove(models.Model):
             "operating_unit_id": ou_id,
             "partner_id": move.partner_id and move.partner_id.id or False,
             "account_id": move.company_id.inter_ou_clearing_account_id.id,
+            "display_type": "ou_balance",
         }
 
         if ou_balances[ou_id] < 0.0:
@@ -170,3 +171,9 @@ class AccountMove(models.Model):
                     )
                 )
         return True
+
+    def button_draft(self):
+        res = super().button_draft()
+        for rec in self:
+            rec.line_ids.filtered(lambda l: l.display_type == "ou_balance").unlink()
+        return res

--- a/account_operating_unit/models/account_move_line.py
+++ b/account_operating_unit/models/account_move_line.py
@@ -12,6 +12,10 @@ class AccountMoveLine(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
     )
+    display_type = fields.Selection(
+        selection_add=[("ou_balance", "OU Balance")],
+        ondelete={"ou_balance": "set product"},
+    )
 
     @api.model_create_multi
     def create(self, vals_list):

--- a/account_operating_unit/static/description/index.html
+++ b/account_operating_unit/static/description/index.html
@@ -1,4 +1,3 @@
-<?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml" xml:lang="en" lang="en">
 <head>
@@ -9,10 +8,11 @@
 
 /*
 :Author: David Goodger (goodger@python.org)
-:Id: $Id: html4css1.css 8954 2022-01-20 10:10:25Z milde $
+:Id: $Id: html4css1.css 9511 2024-01-13 09:50:07Z milde $
 :Copyright: This stylesheet has been placed in the public domain.
 
 Default cascading style sheet for the HTML output of Docutils.
+Despite the name, some widely supported CSS2 features are used.
 
 See https://docutils.sourceforge.io/docs/howto/html-stylesheets.html for how to
 customize this style sheet.
@@ -275,7 +275,7 @@ pre.literal-block, pre.doctest-block, pre.math, pre.code {
   margin-left: 2em ;
   margin-right: 2em }
 
-pre.code .ln { color: grey; } /* line numbers */
+pre.code .ln { color: gray; } /* line numbers */
 pre.code, code { background-color: #eeeeee }
 pre.code .comment, code .comment { color: #5C6576 }
 pre.code .keyword, code .keyword { color: #3B0D06; font-weight: bold }
@@ -301,7 +301,7 @@ span.option {
 span.pre {
   white-space: pre }
 
-span.problematic {
+span.problematic, pre.problematic {
   color: red }
 
 span.section-subtitle {
@@ -488,7 +488,9 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <div class="section" id="maintainers">
 <h2><a class="toc-backref" href="#toc-entry-8">Maintainers</a></h2>
 <p>This module is maintained by the OCA.</p>
-<a class="reference external image-reference" href="https://odoo-community.org"><img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" /></a>
+<a class="reference external image-reference" href="https://odoo-community.org">
+<img alt="Odoo Community Association" src="https://odoo-community.org/logo.png" />
+</a>
 <p>OCA, or the Odoo Community Association, is a nonprofit organization whose
 mission is to support the collaborative development of Odoo features and
 promote its widespread use.</p>

--- a/account_operating_unit/views/account_move_view.xml
+++ b/account_operating_unit/views/account_move_view.xml
@@ -103,6 +103,17 @@
                 </attribute>
             </field>
             <xpath
+                expr="//field[@name='line_ids']/tree//field[@name='account_id']"
+                position="after"
+            >
+                <field
+                    name="operating_unit_id"
+                    options="{'no_create': True}"
+                    optional="show"
+                    groups="operating_unit.group_multi_operating_unit"
+                />
+            </xpath>
+            <xpath
                 expr="//field[@name='invoice_line_ids']/tree//field[@name='account_id']"
                 position="after"
             >


### PR DESCRIPTION
Fixes: https://github.com/OCA/operating-unit/issues/617

FW port of: https://github.com/OCA/operating-unit/pull/705

Converted boolean in the field display_type. Same as Odoo did in here: https://github.com/odoo/odoo/commit/d8d47f9ff8554f4b39487fd2f13c153c7d6f958d

Also added the operating unit column in the journal items list inside the journal entry form. That must be removed by mistake during the migration.

@ForgeFlow
