### PR TITLE
[17.0][IMP] res_partner_operating_unit - remove required on operating_unit_ids

### DIFF
--- a/res_partner_operating_unit/models/res_partner.py
+++ b/res_partner_operating_unit/models/res_partner.py
@@ -19,6 +19,5 @@ class ResPartner(models.Model):
         "partner_id",
         "operating_unit_id",
         "Operating Units",
-        required=True,
         default=lambda self: self._default_operating_unit(),
     )


### PR DESCRIPTION
In my opinion, the field operating_unit_ids should not be required on the partner especially since the security rules are fine to not have operating units