### PR TITLE
[17.0][FIX] operating_unit: rule `operating_unit user` has no group

### DIFF
--- a/operating_unit/security/ir.model.access.csv
+++ b/operating_unit/security/ir.model.access.csv
@@ -1,3 +1,3 @@
 id,name,model_id:id,group_id:id,perm_read,perm_write,perm_create,perm_unlink
 access_account_operating_unit_erp_manager,operating.unit erp.manager,model_operating_unit,group_manager_operating_unit,1,1,1,1
-access_account_operating_unit_user,operating_unit user,model_operating_unit,,1,0,0,0
+access_account_operating_unit_user,operating_unit user,model_operating_unit,group_user_operating_unit,1,0,0,0

--- a/operating_unit/security/operating_unit_security.xml
+++ b/operating_unit/security/operating_unit_security.xml
@@ -8,13 +8,18 @@
         <field name="name">Multiple Operating Unit</field>
         <field name="category_id" ref="module_operating_units" />
     </record>
-    <record id="group_manager_operating_unit" model="res.groups">
-        <field name="name">Manager of Operating Units</field>
+    <record id="group_user_operating_unit" model="res.groups">
+        <field name="name">User of Operating Units</field>
         <field name="implied_ids" eval="[(4, ref('group_multi_operating_unit'))]" />
         <field
             name="users"
             eval="[(4, ref('base.user_root')), (4, ref('base.user_admin'))]"
         />
+        <field name="category_id" ref="module_operating_units" />
+    </record>
+    <record id="group_manager_operating_unit" model="res.groups">
+        <field name="name">Manager of Operating Units</field>
+        <field name="implied_ids" eval="[(4, ref('group_user_operating_unit'))]" />
         <field name="category_id" ref="module_operating_units" />
     </record>
     <record id="operating_unit_comp_rule" model="ir.rule">

--- a/operating_unit/tests/common.py
+++ b/operating_unit/tests/common.py
@@ -13,6 +13,7 @@ class OperatingUnitCommon(common.TransactionCase):
             tracking_disable=True, no_reset_password=True
         )
         # Groups
+        cls.grp_ou_usr = cls.env.ref("operating_unit.group_user_operating_unit")
         cls.grp_ou_mngr = cls.env.ref("operating_unit.group_manager_operating_unit")
         cls.grp_ou_multi = cls.env.ref("operating_unit.group_multi_operating_unit")
         # Company
@@ -27,7 +28,8 @@ class OperatingUnitCommon(common.TransactionCase):
         # Create User 1 with Main OU
         cls.user1 = cls._create_user("user_1", cls.grp_ou_mngr, cls.company, cls.ou1)
         # Create User 2 with B2C OU
-        cls.user2 = cls._create_user("user_2", cls.grp_ou_multi, cls.company, cls.b2c)
+        cls.user2 = cls._create_user("user_2", cls.grp_ou_usr, cls.company, cls.b2c)
+        cls.user2.write({"groups_id": [(4, cls.grp_ou_multi.id)]})
         # Partner
         cls.partner1 = cls.env.ref("base.res_partner_1")
 


### PR DESCRIPTION
Fixes warning in logs:
```
odoo.addons.base.models.ir_model: Rule operating_unit user has no group, this is a deprecated feature. Every access-granting rule should specify a group.
```