### PR TITLE
[FIX] *_operating_unit: add check_company in field OU

### DIFF
--- a/account_asset_operating_unit/models/account_asset.py
+++ b/account_asset_operating_unit/models/account_asset.py
@@ -10,6 +10,7 @@ class AccountAsset(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         string="Operating Unit",
+        check_company=True,
         default=lambda self: self.env["res.users"].operating_unit_default_get(
             self.env.user.id
         ),

--- a/account_operating_unit/models/account_journal.py
+++ b/account_operating_unit/models/account_journal.py
@@ -11,6 +11,7 @@ class AccountJournal(models.Model):
 
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
+        check_company=True,
         help="Operating Unit that will be used in payments, "
         "when this journal is used.",
     )

--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -11,6 +11,7 @@ class AccountMoveLine(models.Model):
 
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
+        check_company=True,
     )
     is_ou_balance = fields.Boolean(readonly=True)
 
@@ -141,6 +142,7 @@ class AccountMove(models.Model):
         default=_default_operating_unit_id,
         help="This operating unit will be defaulted in the move lines.",
         readonly=True,
+        check_company=True,
         states={"draft": [("readonly", False)]},
     )
 

--- a/account_operating_unit/models/account_payment.py
+++ b/account_operating_unit/models/account_payment.py
@@ -11,6 +11,7 @@ class AccountPayment(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         compute="_compute_operating_unit_id",
+        check_company=True,
         store=True,
     )
 

--- a/contract_operating_unit/models/contract.py
+++ b/contract_operating_unit/models/contract.py
@@ -11,6 +11,7 @@ class ContractContract(models.Model):
     operating_unit_id = fields.Many2one(
         "operating.unit",
         "Operating Unit",
+        check_company=True,
         default=lambda self: self.env["res.users"].operating_unit_default_get(
             self._uid
         ),

--- a/hr_expense_operating_unit/models/hr_expense.py
+++ b/hr_expense_operating_unit/models/hr_expense.py
@@ -12,6 +12,7 @@ class HrExpenseExpense(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         string="Operating Unit",
+        check_company=True,
         default=lambda self: self.env["res.users"].operating_unit_default_get(),
     )
 
@@ -91,6 +92,7 @@ class HrExpenseSheet(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         string="Operating Unit",
+        check_company=True,
         default=lambda self: self.env["res.users"].operating_unit_default_get(),
     )
 

--- a/mrp_operating_unit/models/mrp.py
+++ b/mrp_operating_unit/models/mrp.py
@@ -14,6 +14,7 @@ class MrpProduction(models.Model):
         "operating.unit",
         "Operating Unit",
         readonly=True,
+        check_company=True,
         states={"confirmed": [("readonly", False)], "draft": [("readonly", False)]},
         default=lambda self: self.env["res.users"].operating_unit_default_get(
             self._uid

--- a/project_operating_unit/models/project_project.py
+++ b/project_operating_unit/models/project_project.py
@@ -10,6 +10,7 @@ class ProjectProject(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         string="Operating Unit",
+        check_company=True,
         default=lambda self: self.env["res.users"].operating_unit_default_get(
             self._uid
         ),

--- a/project_operating_unit/models/project_task.py
+++ b/project_operating_unit/models/project_task.py
@@ -11,4 +11,5 @@ class ProjectTask(models.Model):
         comodel_name="operating.unit",
         related="project_id.operating_unit_id",
         string="Operating Unit",
+        check_company=True,
     )

--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -19,6 +19,7 @@ class PurchaseOrder(models.Model):
         comodel_name="operating.unit",
         string="Operating Unit",
         states=READONLY_STATES,
+        check_company=True,
         default=lambda self: (
             self.env["res.users"].operating_unit_default_get(self.env.uid)
         ),
@@ -28,6 +29,7 @@ class PurchaseOrder(models.Model):
         comodel_name="operating.unit",
         string="Requesting Operating Unit",
         states=READONLY_STATES,
+        check_company=True,
         default=lambda self: (
             self.env["res.users"].operating_unit_default_get(self.env.uid)
         ),
@@ -58,5 +60,7 @@ class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
     operating_unit_id = fields.Many2one(
-        related="order_id.operating_unit_id", string="Operating Unit"
+        related="order_id.operating_unit_id",
+        string="Operating Unit",
+        check_company=True,
     )

--- a/purchase_request_operating_unit/model/purchase_request.py
+++ b/purchase_request_operating_unit/model/purchase_request.py
@@ -18,6 +18,7 @@ class PurchaseRequest(models.Model):
             "approved": [("readonly", True)],
             "done": [("readonly", True)],
         },
+        check_company=True,
         default=lambda self: self.env["res.users"].operating_unit_default_get(
             self._uid
         ),
@@ -83,4 +84,5 @@ class PurchaseRequestLine(models.Model):
         related="request_id.operating_unit_id",
         string="Operating Unit",
         store=True,
+        check_company=True,
     )

--- a/purchase_requisition_operating_unit/model/purchase_requisition.py
+++ b/purchase_requisition_operating_unit/model/purchase_requisition.py
@@ -13,6 +13,7 @@ class PurchaseRequisition(models.Model):
         comodel_name="operating.unit",
         string="Operating Unit",
         readonly=True,
+        check_company=True,
         states={"draft": [("readonly", False)]},
         default=lambda self: self.env["res.users"].operating_unit_default_get(
             self.env.uid

--- a/sale_operating_unit/models/sale_order.py
+++ b/sale_operating_unit/models/sale_order.py
@@ -20,6 +20,7 @@ class SaleOrder(models.Model):
         comodel_name="operating.unit",
         string="Operating Unit",
         default=_default_operating_unit,
+        check_company=True,
         readonly=True,
         states={"draft": [("readonly", False)], "sent": [("readonly", False)]},
     )

--- a/sales_team_operating_unit/models/crm_team.py
+++ b/sales_team_operating_unit/models/crm_team.py
@@ -12,6 +12,7 @@ class CrmTeam(models.Model):
 
     operating_unit_id = fields.Many2one(
         "operating.unit",
+        check_company=True,
         default=lambda self: self.env["res.users"].operating_unit_default_get(),
     )
 

--- a/stock_operating_unit/model/stock_location.py
+++ b/stock_operating_unit/model/stock_location.py
@@ -11,6 +11,7 @@ class StockLocation(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         string="Operating Unit",
+        check_company=True,
     )
 
     @api.constrains("operating_unit_id")

--- a/stock_operating_unit/model/stock_picking.py
+++ b/stock_operating_unit/model/stock_picking.py
@@ -12,6 +12,7 @@ class StockPicking(models.Model):
         comodel_name="operating.unit",
         string="Requesting Operating Unit",
         readonly=True,
+        check_company=True,
         states={"draft": [("readonly", False)]},
     )
 

--- a/stock_operating_unit/model/stock_warehouse.py
+++ b/stock_operating_unit/model/stock_warehouse.py
@@ -20,6 +20,7 @@ class StockWarehouse(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         string="Operating Unit",
+        check_company=True,
         default=_default_operating_unit,
     )
 


### PR DESCRIPTION
Step to test:
1. Add multi company and create OU
![Selection_019](https://github.com/user-attachments/assets/8992a4db-f78b-49e5-8ebc-8aa53a1fc749)

2. Go to invoice, po, so, exp or else > select Operating Unit field it will show all OU
![Selection_020](https://github.com/user-attachments/assets/9e44643f-2b3b-4a89-b1cb-aabe0e9b38a1)


This document created on `YourCompany` it should select OU that depend on `YourCompany` only
This PR fixed by add `check_company=True` in header field.

Exclude: line, compute field, wizard (may be it should add too. but I didn't test)

After add it
![Selection_021](https://github.com/user-attachments/assets/8f8e2904-24d6-4ae9-bad2-c367a3f1f3cf)
