### PR TITLE
[15.0][FIX] stock_operating_unit: orderpoint OU check for ext locations

### DIFF
--- a/stock_operating_unit/model/stock_warehouse.py
+++ b/stock_operating_unit/model/stock_warehouse.py
@@ -49,6 +49,11 @@ class StockWarehouseOrderPoint(models.Model):
     )
     def _check_location(self):
         for rec in self:
+            # Fix: do not check OU on locations that do not have a warehouse at all
+            # Odoo's base `stock` module will still fill the `warehouse_id` field
+            # incorrectly with the company's default warehouse
+            if not rec.location_id.warehouse_id:
+                continue
             if (
                 rec.warehouse_id.operating_unit_id
                 and rec.warehouse_id


### PR DESCRIPTION
FW Port of https://github.com/OCA/operating-unit/pull/741/

Do not check OU on locations that do not have a warehouse at all Odoo's base `stock` module will still fill the `warehouse_id` field incorrectly with the company's default warehouse

This allows the user to set reordering rules for e.g. a subcontracting location