### PR TITLE
[15.0][FIX] account_operating_unit: Inter OU Balance entry several issues

### DIFF
--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -120,6 +120,7 @@ class AccountMoveLine(models.Model):
             "date": max(self.mapped("date")),
             "ref": "Inter OU Balancing",
             "company_id": journal.company_id.id,
+            "move_type": "entry",
         }
         return move_vals
 

--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -204,11 +204,16 @@ class AccountMove(models.Model):
             "is_ou_balance": True,
             "exclude_from_invoice_tab": True,
         }
-
+        # total_balance_to_match is the minimim of the abs of the values
+        total_balance_to_match = min(
+            abs(ou_balances[ou])
+            for ou in list(ou_balances.keys())
+            if ou_balances[ou] != 0.0
+        )
         if ou_balances[ou_id] < 0.0:
-            res["debit"] = abs(ou_balances[ou_id])
+            res["debit"] = total_balance_to_match
         else:
-            res["credit"] = ou_balances[ou_id]
+            res["credit"] = total_balance_to_match
         return res
 
     def _check_ou_balance(self, move):


### PR DESCRIPTION
Steps to reproduce.

**Issue1: Inter OU Balance Entry is considered invoice**

Choose various invoices from different operating units and create a group payment.

Use a bank journal of one of the operating unit to pay.

The system will create the Inter-OU balance journal entry with type in_invoice. That is not correct. Indeed an error is being raised:

![multi_ou_payment](https://github.com/user-attachments/assets/638b2442-2c9d-4bd5-83ef-fbfaf8e376a6)


**Issue 2: Inter OU balance Entry is unbalanced when matching partial amounts**

Create an invoice for 13000$ for main operating unit
Create a payment for 38000$ for B2B operating unit
Try to apply the payment to the invoice:
![image](https://github.com/user-attachments/assets/16d5586f-8fb5-4c2b-9564-d62476e82aba)

The system will create a debit for 38000$ and a credit for 13000$ for the InterOU Balance entry Causing an error for not balanced JE.

The solution is to InterOU Balance entry only for the amount being reconciled, 13000$
