### PR TITLE
[14.0][FIX]operating_unit: show only user-readable operating units

### DIFF
--- a/operating_unit/models/operating_unit.py
+++ b/operating_unit/models/operating_unit.py
@@ -3,6 +3,7 @@
 # Copyright 2015-TODAY Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from odoo import api, fields, models
+from odoo.exceptions import AccessError
 
 
 class OperatingUnit(models.Model):
@@ -76,3 +77,14 @@ class OperatingUnit(models.Model):
     def write(self, vals):
         self.clear_caches()
         return super(OperatingUnit, self).write(vals)
+
+    def readable_operating_units(self):
+        to_return = self.browse()
+        for ou in self:
+            try:
+                ou.read()
+            except AccessError:
+                continue
+            else:
+                to_return += ou
+        return to_return

--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -63,6 +63,24 @@ class ResUsers(models.Model):
     )
     operating_unit_readonly = fields.Boolean(compute="_compute_operating_unit_readonly")
 
+    @api.depends("operating_unit_ids")
+    def _compute_readable_operating_unit_ids(self):
+        for user in self:
+            readable_operating_units = (
+                user.operating_unit_ids.readable_operating_units()
+            )
+            user.readable_operating_unit_ids = readable_operating_units
+
+    readable_operating_unit_ids = fields.Many2many(
+        "operating.unit",
+        "operating_unit_users_visible_rel",
+        column1="user_id",
+        column2="operating_unit_id",
+        string="Operating Units",
+        compute="_compute_readable_operating_unit_ids",
+        readonly=False,
+    )
+
     @api.onchange("operating_unit_ids")
     def _onchange_operating_unit_ids(self):
         for record in self:
@@ -84,11 +102,16 @@ class ResUsers(models.Model):
                         ("company_id", "=", False),
                         ("company_id", "in", self.env.context["allowed_company_ids"]),
                     ]
-                else:
-                    dom = []
                 user.operating_unit_ids = self.env["operating.unit"].sudo().search(dom)
             else:
-                user.operating_unit_ids = user.assigned_operating_unit_ids
+                old_readable_operating_units = (
+                    user.operating_unit_ids.readable_operating_units()
+                )
+                user.operating_unit_ids = (
+                    user.assigned_operating_unit_ids
+                    - old_readable_operating_units
+                    + user.readable_operating_unit_ids
+                )
 
     @api.depends("groups_id")
     def _compute_operating_unit_readonly(self):

--- a/operating_unit/tests/test_operating_unit.py
+++ b/operating_unit/tests/test_operating_unit.py
@@ -140,7 +140,13 @@ class TestOperatingUnit(common.TransactionCase):
             limit=1,
         )
         partner = self.env["res.partner"].search([], limit=1)
-
+        new_line = self.env["operating.unit"].create(
+            {
+                "partner_id": partner.id,
+                "name": "Test Unit",
+                "code": "007",
+            }
+        )
         with Form(self.env["res.users"], view="base.view_users_form") as user_form:
             user_form.default_operating_unit_id = nou[0]
             user_form.name = "Test Customer"
@@ -148,20 +154,20 @@ class TestOperatingUnit(common.TransactionCase):
 
             # Initially operating_unit_ids is not editable
             with self.assertRaises(AssertionError):
-                user_form.operating_unit_ids._assert_editable()
+                user_form.readable_operating_unit_ids._assert_editable()
 
             # The field is only editable after saving
             user_form.save()
-            with user_form.operating_unit_ids.new() as line:
-                line.partner_id = partner
-                line.name = "Test Unit"
-                line.code = "007"
+            user_form.readable_operating_unit_ids.add(new_line)
 
         self.env["res.users"].browse(user_form.id).groups_id += self.grp_ou_mngr
         user_form = Form(self.env["res.users"], view="base.view_users_form")
         # operating_unit_ids is pre-filled and readonly if the user is OU manager
         with self.assertRaises(AssertionError):
-            user_form.operating_unit_ids._assert_editable()
+            user_form.readable_operating_unit_ids._assert_editable()
+            user_form.readable_operating_unit_ids.add(new_line)
+            user_form.name = "Test Customer"
+            user_form.login = "test2"
 
     def test_03_operating_unit(self):
         """

--- a/operating_unit/view/res_users_view.xml
+++ b/operating_unit/view/res_users_view.xml
@@ -17,15 +17,14 @@
                         they will always have all OUs assigned
                     </span>
                     <field
-                        name="operating_unit_ids"
-                        groups="operating_unit.group_multi_operating_unit"
+                        name="readable_operating_unit_ids"
                         widget="many2many_tags"
                         attrs="{'readonly': [('operating_unit_readonly', '=', True)]}"
+                        groups="operating_unit.group_multi_operating_unit"
                     />
-
                     <field
                         name="default_operating_unit_id"
-                        domain="[('id','in',operating_unit_ids)]"
+                        domain="[('id','in',readable_operating_unit_ids)]"
                     />
                 </group>
             </xpath>


### PR DESCRIPTION
In a multi-company environment there might be cases where our user is in the `operating_unit.group_manager_operating_unit` group and is trying to see another user's form view.
If the other user has been assigned to some Operating Units owned by another company, opening the view results in an access error because we don't have access to the other company's data.

With this PR we handle this case, filtering out all those OU we cannot access