### PR TITLE
[16.0][IMP] report_qweb_operating_unit: Add partner image and other info notice

### DIFF
--- a/report_qweb_operating_unit/README.rst
+++ b/report_qweb_operating_unit/README.rst
@@ -54,14 +54,16 @@ Authors
 
 * ForgeFlow S.L.
 * Serpent Consulting Services Pvt. Ltd.
+* Onestein
 
 Contributors
 ------------
 
--  ForgeFlow S.L. <contact@forgeflow.com>
--  Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
--  Jarsa Sistemas <info@jarsa.com.mx>
--  Juany Davila <juany.davila@forgeflow.com>
+- ForgeFlow S.L. <contact@forgeflow.com>
+- Serpent Consulting Services Pvt. Ltd. <support@serpentcs.com>
+- Jarsa Sistemas <info@jarsa.com.mx>
+- Juany Davila <juany.davila@forgeflow.com>
+- Dennis Sluijk <d.sluijk@onestein.nl>
 
 Maintainers
 -----------

--- a/report_qweb_operating_unit/__manifest__.py
+++ b/report_qweb_operating_unit/__manifest__.py
@@ -9,6 +9,7 @@
     "license": "LGPL-3",
     "author": "ForgeFlow S.L., "
     "Serpent Consulting Services Pvt. Ltd.,"
+    "Onestein,"
     "Odoo Community Association (OCA)",
     "website": "https://github.com/OCA/operating-unit",
     "depends": ["operating_unit"],

--- a/report_qweb_operating_unit/models/operating_unit.py
+++ b/report_qweb_operating_unit/models/operating_unit.py
@@ -34,6 +34,20 @@ class OperatingUnit(models.Model):
     is_operating_unit_details_empty = fields.Boolean(
         compute="_compute_empty_operating_unit_details"
     )
+    partner_image = fields.Image(
+        string="Logo",
+        compute="_compute_partner_image",
+        inverse="_inverse_partner_image",
+    )
+
+    @api.depends("partner_id", "partner_id.image_1920")
+    def _compute_partner_image(self):
+        for operating_unit in self:
+            operating_unit.partner_image = operating_unit.partner_id.image_1920
+
+    def _inverse_partner_image(self):
+        for operating_unit in self:
+            operating_unit.partner_id.image_1920 = operating_unit.partner_image
 
     @api.depends("company_id")
     def _compute_report_header(self):

--- a/report_qweb_operating_unit/readme/CONTRIBUTORS.md
+++ b/report_qweb_operating_unit/readme/CONTRIBUTORS.md
@@ -2,3 +2,4 @@
 - Serpent Consulting Services Pvt. Ltd. \<<support@serpentcs.com>\>
 - Jarsa Sistemas \<<info@jarsa.com.mx>\>
 - Juany Davila \<<juany.davila@forgeflow.com>\>
+- Dennis Sluijk \<<d.sluijk@onestein.nl>\>

--- a/report_qweb_operating_unit/static/description/index.html
+++ b/report_qweb_operating_unit/static/description/index.html
@@ -399,6 +399,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>ForgeFlow S.L.</li>
 <li>Serpent Consulting Services Pvt. Ltd.</li>
+<li>Onestein</li>
 </ul>
 </div>
 <div class="section" id="contributors">
@@ -408,6 +409,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Serpent Consulting Services Pvt. Ltd. &lt;<a class="reference external" href="mailto:support&#64;serpentcs.com">support&#64;serpentcs.com</a>&gt;</li>
 <li>Jarsa Sistemas &lt;<a class="reference external" href="mailto:info&#64;jarsa.com.mx">info&#64;jarsa.com.mx</a>&gt;</li>
 <li>Juany Davila &lt;<a class="reference external" href="mailto:juany.davila&#64;forgeflow.com">juany.davila&#64;forgeflow.com</a>&gt;</li>
+<li>Dennis Sluijk &lt;<a class="reference external" href="mailto:d.sluijk&#64;onestein.nl">d.sluijk&#64;onestein.nl</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/report_qweb_operating_unit/tests/test_report_qweb_operating_unit.py
+++ b/report_qweb_operating_unit/tests/test_report_qweb_operating_unit.py
@@ -39,3 +39,17 @@ class TestReportQwebOperatingUnit(TransactionCase):
                 .decode("utf8")
             )
             self.assertIn(self.ou.report_header, html)
+
+    def test_compute_partner_image(self):
+        empty_image = (
+            b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC"
+            b"0lEQVR42mP8/x8AAwMCAO5WCKsAAAAASUVORK5CYII="
+        )
+        other_image = (
+            b"iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC"
+            b"0lEQVR42mNgYAAAAAMAAWgmWQ0AAAAASUVORK5CYII="
+        )
+        self.ou.partner_image = empty_image
+        self.assertEqual(self.ou.partner_id.image_1920, empty_image)
+        self.ou.partner_id.image_1920 = other_image
+        self.assertEqual(self.ou.partner_image, other_image)

--- a/report_qweb_operating_unit/views/operating_unit_view.xml
+++ b/report_qweb_operating_unit/views/operating_unit_view.xml
@@ -9,6 +9,16 @@
                 <notebook>
                     <page string="Report Layout">
                         <group>
+                            <field
+                                name="partner_image"
+                                widget="image"
+                                options="{'size': [100, 100]}"
+                            />
+                            <p
+                                class="alert alert-info"
+                                colspan="2"
+                                role="alert"
+                            >Address and other information that appear on the report can be changed on the partner form</p>
                             <field name="report_header" />
                             <field name="report_footer" />
                             <field name="operating_unit_details" />


### PR DESCRIPTION
This puts the partner logo which is used on the report directly on the ou form and adds a notice for the user that refers to the partner form.
![image](https://github.com/user-attachments/assets/6de9bbfc-5e71-4658-aad3-38eb06be766d)
