### PR TITLE
[15.0][FIX] operating_unit: get default OU from correct field

### DIFF
--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -19,11 +19,11 @@ class ResUsers(models.Model):
             return user.default_operating_unit_id
         else:
             # find an OU of the main active company
-            for ou in user.assigned_operating_unit_ids:
+            for ou in user.operating_unit_ids:
                 if ou.sudo().company_id in self.env.company:
                     return ou
             # find an OU of any active company
-            for ou in user.assigned_operating_unit_ids:
+            for ou in user.operating_unit_ids:
                 if ou.sudo().company_id in self.env.companies:
                     return ou
         return False
@@ -51,6 +51,8 @@ class ResUsers(models.Model):
         column2="operating_unit_id",
         string="Operating Units",
         default=lambda self: self._default_operating_units(),
+        help="Technical field. Refer to `operating_unit_ids` if you need to "
+        "check if an OU is assigned to a user.",
     )
 
     default_operating_unit_id = fields.Many2one(
@@ -59,6 +61,7 @@ class ResUsers(models.Model):
         default=lambda self: self._default_operating_unit(),
         domain="[('company_id', '=', current_company_id)]",
     )
+    operating_unit_readonly = fields.Boolean(compute="_compute_operating_unit_readonly")
 
     @api.onchange("operating_unit_ids")
     def _onchange_operating_unit_ids(self):
@@ -86,6 +89,13 @@ class ResUsers(models.Model):
                 user.operating_unit_ids = self.env["operating.unit"].sudo().search(dom)
             else:
                 user.operating_unit_ids = user.assigned_operating_unit_ids
+
+    @api.depends("groups_id")
+    def _compute_operating_unit_readonly(self):
+        for user in self:
+            user.operating_unit_readonly = user.has_group(
+                "operating_unit.group_manager_operating_unit"
+            )
 
     @api.model
     def default_get(self, fields):

--- a/operating_unit/tests/test_operating_unit.py
+++ b/operating_unit/tests/test_operating_unit.py
@@ -140,14 +140,28 @@ class TestOperatingUnit(common.TransactionCase):
             limit=1,
         )
         partner = self.env["res.partner"].search([], limit=1)
+
         with Form(self.env["res.users"], view="base.view_users_form") as user_form:
             user_form.default_operating_unit_id = nou[0]
+            user_form.name = "Test Customer"
+            user_form.login = "test2"
+
+            # Initially operating_unit_ids is not editable
+            with self.assertRaises(AssertionError):
+                user_form.operating_unit_ids._assert_editable()
+
+            # The field is only editable after saving
+            user_form.save()
             with user_form.operating_unit_ids.new() as line:
                 line.partner_id = partner
                 line.name = "Test Unit"
                 line.code = "007"
-            user_form.name = "Test Customer"
-            user_form.login = "test2"
+
+        self.env["res.users"].browse(user_form.id).groups_id += self.grp_ou_mngr
+        user_form = Form(self.env["res.users"], view="base.view_users_form")
+        # operating_unit_ids is pre-filled and readonly if the user is OU manager
+        with self.assertRaises(AssertionError):
+            user_form.operating_unit_ids._assert_editable()
 
     def test_03_operating_unit(self):
         """
@@ -169,7 +183,7 @@ class TestOperatingUnit(common.TransactionCase):
         ou_company_2 = self._create_operating_unit(
             self.user1.id, "Test Company", "TESTC", self.company_2
         )
-        self.user1.assigned_operating_unit_ids += ou_company_2
+        self.user1.operating_unit_ids += ou_company_2
         self.assertEqual(
             self.res_users_model.with_company(
                 self.company_2

--- a/operating_unit/view/res_users_view.xml
+++ b/operating_unit/view/res_users_view.xml
@@ -7,10 +7,20 @@
         <field name="arch" type="xml">
             <xpath expr="//page[@name='access_rights']/group[1]" position="after">
                 <group string="Operating Units">
+                    <field name="operating_unit_readonly" invisible="1" />
+                    <span
+                        class="fa fa-warning"
+                        colspan="2"
+                        attrs="{'invisible': [('operating_unit_readonly', '=', False)]}"
+                    >
+                        If the user is Manager of Operating Units
+                        they will always have all OUs assigned
+                    </span>
                     <field
                         name="operating_unit_ids"
                         groups="operating_unit.group_multi_operating_unit"
                         widget="many2many_tags"
+                        attrs="{'readonly': [('operating_unit_readonly', '=', True)]}"
                     />
 
                     <field


### PR DESCRIPTION
FW: https://github.com/OCA/operating-unit/pull/766/

This commit also clarifies the usage of the two OU-related fields in the user, both for devs and for end users.