### PR TITLE
[18.0][FIX] operating_unit: get default OU from correct field

### DIFF
--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -23,6 +23,8 @@ class ResUsers(models.Model):
         column2="operating_unit_id",
         string="Operating Units",
         default=lambda self: self._default_operating_unit(),
+        help="Technical field. Refer to `operating_unit_ids` if you need to "
+        "check if an OU is assigned to a user.",
     )
 
     default_operating_unit_id = fields.Many2one(
@@ -31,6 +33,7 @@ class ResUsers(models.Model):
         default=lambda self: self._default_operating_unit(),
         domain="[('company_id', '=', current_company_id)]",
     )
+    operating_unit_readonly = fields.Boolean(compute="_compute_operating_unit_readonly")
 
     @api.model
     def _get_default_operating_unit(self, uid2=False):
@@ -42,11 +45,11 @@ class ResUsers(models.Model):
             return user.default_operating_unit_id
         else:
             # find an OU of the main active company
-            for ou in user.assigned_operating_unit_ids:
+            for ou in user.operating_unit_ids:
                 if ou.sudo().company_id in self.env.company:
                     return ou
             # find an OU of any active company
-            for ou in user.assigned_operating_unit_ids:
+            for ou in user.operating_unit_ids:
                 if ou.sudo().company_id in self.env.companies:
                     return ou
         return False
@@ -70,6 +73,13 @@ class ResUsers(models.Model):
             )
             vals["operating_unit_ids"] = [(6, 0, default_user.operating_unit_ids.ids)]
         return vals
+
+    @api.depends("groups_id")
+    def _compute_operating_unit_readonly(self):
+        for user in self:
+            user.operating_unit_readonly = user.has_group(
+                "operating_unit.group_manager_operating_unit"
+            )
 
     @api.depends("groups_id", "assigned_operating_unit_ids")
     def _compute_operating_unit_ids(self):

--- a/operating_unit/tests/test_operating_unit.py
+++ b/operating_unit/tests/test_operating_unit.py
@@ -89,6 +89,20 @@ class TestOperatingUnit(OperatingUnitCommon):
             user_form.name = "Test Customer"
             user_form.login = "test2"
 
+        # operating_unit_ids is pre-filled and readonly if the user is OU manager
+        user = self.env["res.users"].browse(user_form.id)
+        user.groups_id += self.grp_ou_mngr
+        user_form = Form(user, view="base.view_users_form")
+        with self.assertRaises(AssertionError):
+            user_form.operating_unit_ids._assert_editable()
+        # and editable again without it
+        user.groups_id -= self.grp_ou_mngr
+        with Form(user, view="base.view_users_form") as user_form:
+            with user_form.operating_unit_ids.new() as line:
+                line.partner_id = partner
+                line.name = "Test Unit 2"
+                line.code = "008"
+
     def test_find_operating_unit_by_name_or_code(self):
         ou = self._create_operating_unit(self.user1.id, "name", "code")
         expected_result = [(ou.id, "[code] name")]
@@ -116,7 +130,7 @@ class TestOperatingUnit(OperatingUnitCommon):
         ou_company_2 = self._create_operating_unit(
             self.user1.id, "Test Company", "TESTC", self.company_2
         )
-        self.user1.assigned_operating_unit_ids += ou_company_2
+        self.user1.operating_unit_ids += ou_company_2
         self.assertEqual(
             self.res_users_model.with_company(
                 self.company_2

--- a/operating_unit/view/res_users_view.xml
+++ b/operating_unit/view/res_users_view.xml
@@ -10,7 +10,20 @@
                     string="Operating Units"
                     groups="operating_unit.group_multi_operating_unit"
                 >
-                    <field name="operating_unit_ids" widget="many2many_tags" />
+                    <field name="operating_unit_readonly" invisible="1" />
+                    <span
+                        class="fa fa-warning"
+                        colspan="2"
+                        invisible="not operating_unit_readonly"
+                    >
+                        If the user is Manager of Operating Units
+                        they will always have all OUs assigned
+                    </span>
+                    <field
+                        name="operating_unit_ids"
+                        widget="many2many_tags"
+                        readonly="operating_unit_readonly"
+                    />
 
                     <field
                         name="default_operating_unit_id"


### PR DESCRIPTION
FW of https://github.com/OCA/operating-unit/pull/777/ and indirectly of https://github.com/OCA/operating-unit/pull/766/

This commit also clarifies the usage of the two OU-related fields in the user, both for devs and for end users.