### PR TITLE
[16.0] operating_unit: Remove assigning operating unit to root user

### DIFF
--- a/operating_unit/data/operating_unit_data.xml
+++ b/operating_unit/data/operating_unit_data.xml
@@ -6,10 +6,6 @@
         <field name="code">OU1</field>
         <field name="partner_id" ref="base.main_partner" />
     </record>
-    <record model="res.users" id="base.user_root">
-        <field name="default_operating_unit_id" ref="main_operating_unit" />
-        <field name="operating_unit_ids" eval="[(4, ref('main_operating_unit'))]" />
-    </record>
     <record model="res.users" id="base.user_admin">
         <field name="default_operating_unit_id" ref="main_operating_unit" />
         <field name="operating_unit_ids" eval="[(4, ref('main_operating_unit'))]" />


### PR DESCRIPTION
This (the assigning of an operating unit to the root user) has a downstream impact where the sales teams get assigned an operating unit (sales_team_operating_unit) and consequently also all sales (sale_operating_unit) when the respective modules are installed. IMO this module should not touch any existing records and let records have initial null as operating unit.

Also explained in https://github.com/OCA/operating-unit/issues/784