### PR TITLE
[14.0][FIX] operating_unit: allow access to user without all companies active

### DIFF
--- a/operating_unit/models/res_users.py
+++ b/operating_unit/models/res_users.py
@@ -74,21 +74,23 @@ class ResUsers(models.Model):
                 record.default_operating_unit_id = False
 
     @api.depends("groups_id", "assigned_operating_unit_ids")
+    @api.depends_context("allowed_company_ids")
     def _compute_operating_unit_ids(self):
+        if self.env.context.get("allowed_company_ids"):
+            dom = [
+                "|",
+                ("company_id", "=", False),
+                ("company_id", "in", self.env.context["allowed_company_ids"]),
+            ]
+        else:
+            dom = []
         for user in self:
             if user.has_group("operating_unit.group_manager_operating_unit"):
-                dom = []
-                if self.env.context.get("allowed_company_ids"):
-                    dom = [
-                        "|",
-                        ("company_id", "=", False),
-                        ("company_id", "in", self.env.context["allowed_company_ids"]),
-                    ]
-                else:
-                    dom = []
-                user.operating_unit_ids = self.env["operating.unit"].sudo().search(dom)
+                user.operating_unit_ids = self.env["operating.unit"].search(dom)
             else:
-                user.operating_unit_ids = user.assigned_operating_unit_ids
+                user.operating_unit_ids = (
+                    user.assigned_operating_unit_ids.filtered_domain(dom)
+                )
 
     @api.depends("groups_id")
     def _compute_operating_unit_readonly(self):


### PR DESCRIPTION
Steps to reproduce:

1. Install `operating_unit` on a fresh DB
2. Create Company 2
3. Activate only Company 2
4. Enter Marc Demo's user 

Error: 
`Due to security restrictions, you are not allowed to access 'Operating Unit' (operating.unit) records.`

