### PR TITLE
[15.0][FIX] account_asset_operating_unit: skip onchange invoice line when create move depreciation

### DIFF
--- a/account_asset_operating_unit/models/account_asset_line.py
+++ b/account_asset_operating_unit/models/account_asset_line.py
@@ -16,6 +16,7 @@ class AccountAssetLine(models.Model):
     def create_move(self):
         created_move_ids = super().create_move()
         moves = self.env["account.move"].browse(created_move_ids)
+        moves = moves.with_context(skip_onchange_invoice_line=True)
         for move in moves:
             move._onchange_invoice_line_ids()
         return created_move_ids


### PR DESCRIPTION
depends : https://github.com/OCA/operating-unit/pull/795