### PR TITLE
[18.0][FIX] account_operating_unit: adapt payment state check

### DIFF
--- a/account_operating_unit/tests/test_payment_operating_unit.py
+++ b/account_operating_unit/tests/test_payment_operating_unit.py
@@ -38,7 +38,7 @@ class TestInvoiceOperatingUnit(test_ou.TestAccountOperatingUnit):
         # Validate that inter OU balance move lines are created
         self.assertEqual(len(payment.move_id.line_ids), 4)
         self.assertAlmostEqual(payment.amount, self.invoice.amount_total)
-        self.assertEqual(payment.state, "paid")
+        self.assertIn(payment.state, ["paid", "in_process"])
         self.assertEqual(self.invoice.payment_state, "paid")
 
     def test_payment_from_two_invoices(self):
@@ -77,7 +77,7 @@ class TestInvoiceOperatingUnit(test_ou.TestAccountOperatingUnit):
             # Validate that inter OU balance move lines are created
             self.assertEqual(len(payment.move_id.line_ids), 2)
             self.assertEqual(payment.amount, invoices[0].amount_total)
-            self.assertEqual(payment.state, "paid")
+            self.assertIn(payment.state, ["paid", "in_process"])
         for invoice in invoices:
             self.assertEqual(invoice.payment_state, "paid")
 


### PR DESCRIPTION
Issue :-

In Odoo 18, the payment workflow introduces an intermediate state "in_process" before a payment is fully reconciled and marked as "paid".
This change affects existing tests that expect the payment state to be "paid" immediately after action_create_payments().

As a result, the following tests were failing:
- test_payment_from_invoice
- test_payment_from_two_invoices

Issue Reference:
- https://github.com/OCA/operating-unit/pull/756
- https://github.com/OCA/operating-unit/pull/728
- https://github.com/OCA/operating-unit/pull/727