### PR TITLE
[16.0][FIX] sale_stock_operating_unit: Reverted change in onchange_team_id

### DIFF
--- a/sale_stock_operating_unit/models/sale_order.py
+++ b/sale_stock_operating_unit/models/sale_order.py
@@ -35,9 +35,9 @@ class SaleOrder(models.Model):
         comodel_name="stock.warehouse", default=_default_warehouse_id
     )
 
-    @api.depends("team_id")
-    def _compute_team_id(self):
-        res = super()._compute_team_id()
+    @api.onchange("team_id")
+    def onchange_team_id(self):
+        res = super(SaleOrder, self).onchange_team_id()
         if (
             self.team_id
             and self.team_id.operating_unit_id


### PR DESCRIPTION
Hey @AaronHForgeFlow, 

in the migration of this module to v16.0 I think there was a mistake: https://github.com/OCA/operating-unit/pull/797

- The obvious issue is, that the function onchange_team_id  was just converted from onchange to compute, without adding a for loop. This will break, if we have to compute for multiple sale orders.
- Anyway, I am not sure if we should have changed it to compute in the first place. Actually the functionality should still be given by using the onchange method. We do the same in sale_operating_unit https://github.com/OCA/operating-unit/blob/16.0/sale_operating_unit/models/sale_order.py#L28. 