### PR TITLE
[14.0][FIX] purchase_operating_unit: create PO with warehouse without OU

### DIFF
--- a/purchase_operating_unit/models/purchase_order.py
+++ b/purchase_operating_unit/models/purchase_order.py
@@ -101,11 +101,18 @@ class PurchaseOrder(models.Model):
             types = type_obj.search(
                 [
                     ("code", "=", "incoming"),
-                    ("warehouse_id.operating_unit_id", "=", self.operating_unit_id.id),
-                ]
+                    (
+                        "warehouse_id.operating_unit_id",
+                        "in",
+                        [self.operating_unit_id.id, False],
+                    ),
+                ],
             )
             if types:
-                self.picking_type_id = types[:1]
+                # Prefer types with an operating unit, if multiple are available
+                self.picking_type_id = types.sorted(
+                    lambda x: x.warehouse_id.operating_unit_id
+                )[:1]
             else:
                 raise UserError(
                     _(

--- a/purchase_operating_unit/tests/test_po_security.py
+++ b/purchase_operating_unit/tests/test_po_security.py
@@ -2,6 +2,8 @@
 # - Jordi Ballester Alomar
 # © 2015-17 Serpent Consulting Services Pvt. Ltd. - Sudhir Arya
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from odoo.tests.common import Form
+
 from . import test_purchase_operating_unit as test_po_ou  # noqa
 
 
@@ -52,3 +54,17 @@ class TestPoSecurity(test_po_ou.TestPurchaseOperatingUnit):
             .ids
         )
         self.assertNotEqual(invoice_ids, [])
+
+    def test_create_po_warehouse_ou(self):
+        # create a PO with warehouse with OU
+        warehouse = self.env.ref("stock.warehouse0")
+        self.assertEqual(warehouse.operating_unit_id, self.ou1)
+        with Form(self.PurchaseOrder.with_user(self.user1_id)) as f:
+            f.partner_id = self.partner1
+        self.assertEqual(f.picking_type_id.warehouse_id, warehouse)
+
+        # create a PO with warehouse without OU
+        warehouse.operating_unit_id = False
+        with Form(self.PurchaseOrder.with_user(self.user1_id)) as f:
+            f.partner_id = self.partner1
+        self.assertEqual(f.picking_type_id.warehouse_id, warehouse)


### PR DESCRIPTION
This commit fixes an issue where, if there is only one warehouse visible to the user and that warehouse has no Operating Unit (so it's available for all regardless of OU), PO creation fails with an error.

In case of multiple warehouses being available (with and without OUs) the one with the OU is preferred and used over the others.