### PR TITLE
[14.0][FIX] account_operating_unit: Manager can select all OUs

### DIFF
--- a/account_operating_unit/README.rst
+++ b/account_operating_unit/README.rst
@@ -128,6 +128,9 @@ Contributors
 * Jarsa Sistemas <info@jarsa.com.mx>
 * Alan Ramos <alan.ramos@jarsa.com.mx>
 * Hieu, Vo Minh Bao <hieu.vmb@komit-consulting.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>
 
 Maintainers
 ~~~~~~~~~~~

--- a/account_operating_unit/models/account_journal.py
+++ b/account_operating_unit/models/account_journal.py
@@ -11,7 +11,6 @@ class AccountJournal(models.Model):
 
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
-        domain="[('user_ids', '=', uid)]",
         help="Operating Unit that will be used in payments, "
         "when this journal is used.",
     )

--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -10,7 +10,7 @@ class AccountMoveLine(models.Model):
     _inherit = "account.move.line"
 
     operating_unit_id = fields.Many2one(
-        comodel_name="operating.unit", domain="[('user_ids', '=', uid)]"
+        comodel_name="operating.unit",
     )
 
     @api.model_create_multi
@@ -138,7 +138,6 @@ class AccountMove(models.Model):
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
         default=_default_operating_unit_id,
-        domain="[('user_ids', '=', uid)]",
         help="This operating unit will be defaulted in the move lines.",
         readonly=True,
         states={"draft": [("readonly", False)]},

--- a/account_operating_unit/models/account_payment.py
+++ b/account_operating_unit/models/account_payment.py
@@ -16,7 +16,6 @@ class AccountPayment(models.Model):
 
     operating_unit_id = fields.Many2one(
         comodel_name="operating.unit",
-        domain="[('user_ids', '=', uid)]",
         compute="_compute_operating_unit_id",
         store=True,
     )

--- a/account_operating_unit/readme/CONTRIBUTORS.rst
+++ b/account_operating_unit/readme/CONTRIBUTORS.rst
@@ -7,3 +7,6 @@
 * Jarsa Sistemas <info@jarsa.com.mx>
 * Alan Ramos <alan.ramos@jarsa.com.mx>
 * Hieu, Vo Minh Bao <hieu.vmb@komit-consulting.com>
+* `PyTech <https://www.pytech.it>`_:
+
+  * Simone Rubino <simone.rubino@pytech.it>

--- a/account_operating_unit/static/description/index.html
+++ b/account_operating_unit/static/description/index.html
@@ -480,6 +480,10 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <li>Jarsa Sistemas &lt;<a class="reference external" href="mailto:info&#64;jarsa.com.mx">info&#64;jarsa.com.mx</a>&gt;</li>
 <li>Alan Ramos &lt;<a class="reference external" href="mailto:alan.ramos&#64;jarsa.com.mx">alan.ramos&#64;jarsa.com.mx</a>&gt;</li>
 <li>Hieu, Vo Minh Bao &lt;<a class="reference external" href="mailto:hieu.vmb&#64;komit-consulting.com">hieu.vmb&#64;komit-consulting.com</a>&gt;</li>
+<li><a class="reference external" href="https://www.pytech.it">PyTech</a>:<ul>
+<li>Simone Rubino &lt;<a class="reference external" href="mailto:simone.rubino&#64;pytech.it">simone.rubino&#64;pytech.it</a>&gt;</li>
+</ul>
+</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/account_operating_unit/tests/test_account_operating_unit.py
+++ b/account_operating_unit/tests/test_account_operating_unit.py
@@ -5,6 +5,7 @@
 import odoo.tests
 
 from odoo.addons.account.tests.common import AccountTestInvoicingCommon
+from odoo.addons.mail.tests.common import mail_new_test_user
 
 
 @odoo.tests.tagged("post_install", "-at_install")
@@ -22,6 +23,7 @@ class TestAccountOperatingUnit(AccountTestInvoicingCommon):
 
         # company
         self.company = self.env.user.company_id
+        self.grp_ou_manager_xmlid = "operating_unit.group_manager_operating_unit"
         self.grp_acc_manager = self.env.ref("account.group_account_manager")
         # Main Operating Unit
         self.ou1 = self.env.ref("operating_unit.main_operating_unit")
@@ -68,6 +70,18 @@ class TestAccountOperatingUnit(AccountTestInvoicingCommon):
                 "groups_id": [(6, 0, [self.grp_acc_manager.id])],
             }
         )
+        admin_groups = self.env.ref("base.user_admin").groups_id
+        self.ou_manager_user = mail_new_test_user(
+            self.env,
+            login="OU Manager",
+            groups=",".join(
+                [xmlid for gid, xmlid in admin_groups.get_external_id().items()]
+                + [
+                    self.grp_ou_manager_xmlid,
+                ]
+            ),
+        )
+
         # Create cash - test account
         user_type = self.env.ref("account.data_account_type_current_assets")
         self.current_asset_account_id = self.account_model.create(

--- a/account_operating_unit/tests/test_invoice_operating_unit.py
+++ b/account_operating_unit/tests/test_invoice_operating_unit.py
@@ -2,12 +2,13 @@
 # © 2019 Serpent Consulting Services Pvt. Ltd.
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
-import odoo.tests
+from odoo import tests
+from odoo.tools.safe_eval import safe_eval
 
 from . import test_account_operating_unit as test_ou
 
 
-@odoo.tests.tagged("post_install", "-at_install")
+@tests.tagged("post_install", "-at_install")
 class TestInvoiceOperatingUnit(test_ou.TestAccountOperatingUnit):
     def test_create_invoice_validate(self):
         """Create & Validate the invoice.
@@ -33,3 +34,32 @@ class TestInvoiceOperatingUnit(test_ou.TestAccountOperatingUnit):
             False,
             "Journal Entries have different Operating Units.",
         )
+
+    def test_manager_select_operating_unit(self):
+        """A Manager of Operating Units can
+        assign any Operating Unit to an invoice."""
+        # Arrange
+        manager_user = self.ou_manager_user
+        # pre-condition
+        self.assertTrue(manager_user.has_group(self.grp_ou_manager_xmlid))
+
+        # Act
+        invoice_form = tests.Form(self.move_model.with_user(manager_user.id))
+        invoice = invoice_form.save()
+
+        # Assert
+        invoice_form_OU_field = invoice_form._view["fields"]["operating_unit_id"]
+        selectable_OUs_domain = safe_eval(
+            invoice_form_OU_field.get("domain") or "[]",
+            globals_dict=dict(
+                invoice.read()[0],
+                uid=invoice.env.uid,
+            ),
+        )
+        selectable_OUs = (
+            self.env["operating.unit"]
+            .with_user(manager_user.id)
+            .search(selectable_OUs_domain)
+        )
+        manager_OUs = manager_user.with_company(invoice.company_id).operating_unit_ids
+        self.assertEqual(manager_OUs, selectable_OUs)


### PR DESCRIPTION
Steps:
1. Create a Manager of Operating Units
2. Create some Operating Units
3. Log in as the created Manager
4. Create an Invoice
5. Click on the Operating Unit field

Before this change:
Not all Operating Units can be selected.

After this change:
All Operating Units can be selected.