### PR TITLE
[18.0][FW] [17.0][IMP] account_operating_unit: account.move::_default_operating_unit_id

### DIFF
--- a/account_operating_unit/models/account_move.py
+++ b/account_operating_unit/models/account_move.py
@@ -116,10 +116,13 @@ class AccountMove(models.Model):
 
     @api.model
     def _default_operating_unit_id(self):
+        if journal_id := self._context.get("default_journal_id"):
+            journal = self.env["account.journal"].browse(journal_id)
+            if journal_ou := journal.operating_unit_id:
+                return journal_ou
         if (
-            self._context.get("default_move_type", False)
-            and self._context.get("default_move_type") != "entry"
-        ):
+            move_type := self._context.get("default_move_type")
+        ) and move_type != "entry":
             return self.env["res.users"]._get_default_operating_unit()
         return False
 


### PR DESCRIPTION
`account.move` should default on the journal's operating unit (if set) instead of the user's operating unit