### PR TITLE
[19.0][IMP] operating_unit: Add sheet to form view

### DIFF
--- a/operating_unit/view/operating_unit_view.xml
+++ b/operating_unit/view/operating_unit_view.xml
@@ -5,13 +5,15 @@
         <field name="model">operating.unit</field>
         <field name="arch" type="xml">
             <form string="Operating Unit">
-                <group name="main_group">
-                    <field name="name" />
-                    <field name="code" />
-                    <field name="active" />
-                    <field name="partner_id" />
-                    <field name="company_id" groups="base.group_multi_company" />
-                </group>
+                <sheet>
+                    <group name="main_group">
+                        <field name="name" />
+                        <field name="code" />
+                        <field name="active" />
+                        <field name="partner_id" />
+                        <field name="company_id" groups="base.group_multi_company" />
+                    </group>
+                </sheet>
             </form>
         </field>
     </record>


### PR DESCRIPTION
Add a `<sheet>` container to the form view.
This simplifies view inheritance in dependent modules, specifically to allow easier addition of a chatter.