### PR TITLE
[17.0][IMP] mail_operating_unit: support single operating_unit_ids and add OU mail server routing

### DIFF
--- a/mail_operating_unit/README.rst
+++ b/mail_operating_unit/README.rst
@@ -32,7 +32,23 @@ Mail Operating Unit
 
 |badge1| |badge2| |badge3| |badge4| |badge5|
 
-This module allows to link an Email Domain to an Operating Unit.
+This module allows companies working with multiple Operating Units to
+send emails with the appropriate email domain and, optionally, the
+appropriate outgoing mail server depending on the Operating Unit
+context.
+
+It lets you define an Alias Domain on an Operating Unit and use that
+domain automatically when emails are generated from templates or records
+linked to that Operating Unit.
+
+It also allows you to define an Outgoing Mail Server on an Operating
+Unit and automatically route emails through that server when no mail
+server is explicitly defined on the email template.
+
+This is especially useful in multi-brand or multi-entity environments
+where each Operating Unit must send emails using its own domain and SMTP
+server, while still keeping the standard Odoo behavior as a fallback
+when no specific Operating Unit configuration can be determined.
 
 **Table of contents**
 
@@ -44,8 +60,18 @@ Configuration
 
 To configure this module, you need to:
 
-- Assign *Alias Domain* to an Operating Unit.
-- Assign *Operating Unit* to an Email Template
+- Assign an *Alias Domain* to each Operating Unit that should use a
+  specific email domain.
+- Assign an *Operating Unit* to an Email Template when emails sent from
+  that template must use the alias domain of that operating unit.
+- Optionally assign an *Outgoing Mail Server* to an Operating Unit when
+  emails should be routed through a specific SMTP server.
+
+When no operating unit is defined on the template or on the target
+record, the standard Odoo alias domain behavior is applied.
+
+When no unambiguous Operating Unit mail server can be determined, the
+standard Odoo outgoing mail server selection is applied.
 
 Bug Tracker
 ===========
@@ -70,6 +96,7 @@ Contributors
 
 - Vincent Van Rossem <vincent.vanrossem@camptocamp.com>
 - Italo Lopes <italo.lopes@camptocamp.com>
+- Maksym Yankin <maksym.yankin@camptocamp.com>
 
 Maintainers
 -----------

--- a/mail_operating_unit/__manifest__.py
+++ b/mail_operating_unit/__manifest__.py
@@ -10,6 +10,7 @@
     "category": "Productivity/Discuss",
     "depends": ["mail", "operating_unit"],
     "data": [
+        # Views
         "views/mail_template.xml",
         "views/operating_unit.xml",
     ],

--- a/mail_operating_unit/models/__init__.py
+++ b/mail_operating_unit/models/__init__.py
@@ -1,4 +1,6 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from . import models
+
+from . import mail_mail
 from . import mail_template
+from . import models
 from . import operating_unit

--- a/mail_operating_unit/models/mail_mail.py
+++ b/mail_operating_unit/models/mail_mail.py
@@ -1,0 +1,64 @@
+# Copyright 2026 Camptocamp SA
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+import logging
+
+from odoo import fields, models
+
+_logger = logging.getLogger(__name__)
+
+
+class MailMail(models.Model):
+    _inherit = "mail.mail"
+
+    operating_unit_id = fields.Many2one("operating.unit", string="Operating Unit")
+
+    def _send(
+        self,
+        auto_commit=False,
+        raise_exception=False,
+        smtp_session=None,
+        alias_domain_id=False,
+    ):
+        # OVERRIDE: to assign an OU mail server when no explicit mail server is set.
+
+        # Template mail server keeps the highest priority,
+        # because it is already stored on ``mail.mail.mail_server_id``
+        # before this method is called.
+        no_mail_server_mails = self.filtered(
+            lambda mail: not mail.mail_server_id and mail.model and mail.res_id
+        )
+        for mail in no_mail_server_mails:
+            # Check if the related record actually exists,
+            # as the mail could be linked to a deleted record.
+            record = self.env[mail.model].browse(mail.res_id).exists()
+            if not record:
+                continue
+
+            if mail_server := record._mail_get_operating_unit_mail_server():
+                mail.write({"mail_server_id": mail_server.id})
+                # Log the information about the resolved mail server
+                # and the OU for each mail being sent.
+                _logger.debug(
+                    "mail_operating_unit: using operating unit mail server %s (%s) "
+                    "from OU [%s] for record %s(%s)",
+                    mail_server.display_name,
+                    mail_server.id,
+                    record._mail_get_operating_unit_label(),
+                    record._name,
+                    record.id,
+                )
+            else:
+                _logger.debug(
+                    "mail_operating_unit: no operating unit mail server resolved "
+                    "from OU [%s] for record %s(%s), falling back to default behavior",
+                    record._mail_get_operating_unit_label(),
+                    record._name,
+                    record.id,
+                )
+
+        return super()._send(
+            auto_commit=auto_commit,
+            raise_exception=raise_exception,
+            smtp_session=smtp_session,
+            alias_domain_id=alias_domain_id,
+        )

--- a/mail_operating_unit/models/mail_template.py
+++ b/mail_operating_unit/models/mail_template.py
@@ -17,7 +17,8 @@ class MailTemplate(models.Model):
         email_values=None,
         email_layout_xmlid=False,
     ):
-        # Include in the email values the alias domain ID of the current OU if any
+        # OVERRIDE: to include in the email values
+        # the alias domain ID of the current OU if any
         email_values = email_values or {}
         if self.operating_unit_id and self.operating_unit_id.alias_domain_id:
             email_values["record_alias_domain_id"] = (

--- a/mail_operating_unit/models/models.py
+++ b/mail_operating_unit/models/models.py
@@ -10,16 +10,26 @@ class BaseModel(models.AbstractModel):
     def _mail_get_operating_unit(self):
         """Retrieves the operating unit ID if it exists and is truthy.
 
-        This method checks if the instance has the attribute `operating_unit_id`
+        This method checks if the instance has the attribute
+        either `operating_unit_id` or `operating_unit_ids`
         and whether it holds a truthy value.
-        If both conditions are met, it returns the value of `operating_unit_id`.
+        If both conditions are met, in case of `operating_unit_id`
+        it returns the value of `operating_unit_id`.
+        In case of `operating_unit_ids`, if exactly one operating unit is set,
+        it returns the single record of the recordset.
         Otherwise, it returns `False`.
         """
-        return (
-            self.operating_unit_id
-            if "operating_unit_id" in self and self.operating_unit_id
-            else False
-        )
+        if "operating_unit_id" in self._fields and self.operating_unit_id:
+            return self.operating_unit_id
+        if "operating_unit_ids" in self._fields:
+            operating_units = self.operating_unit_ids
+            if (
+                operating_units
+                and len(operating_units) == 1
+                and operating_units.alias_domain_id
+            ):
+                return operating_units
+        return False
 
     def _mail_get_operating_units(self):
         """Retrieve the operating unit (OU) based on specific criteria.
@@ -72,3 +82,47 @@ class BaseModel(models.AbstractModel):
             )
             for record in self
         }
+
+    def _mail_get_operating_unit_mail_server(self):
+        """Return the operating unit outgoing mail server.
+
+        Resolution rules:
+        - use ``operating_unit_id.mail_server_id`` when available;
+        - use the shared mail server from ``operating_unit_ids`` when all
+          operating units point to the same one;
+        - otherwise, if the current user's default operating unit belongs to
+          ``operating_unit_ids`` and has a mail server, use it;
+        - otherwise return ``False``.
+        """
+        self.ensure_one()
+        if "operating_unit_id" in self._fields and self.operating_unit_id:
+            return self.operating_unit_id.mail_server_id
+        if "operating_unit_ids" in self._fields and self.operating_unit_ids:
+            mail_servers = self.operating_unit_ids.mapped("mail_server_id")
+            if mail_servers and len(mail_servers) == 1:
+                return mail_servers
+
+            default_operating_unit = self.env.user._get_default_operating_unit()
+            if (
+                default_operating_unit
+                and default_operating_unit in self.operating_unit_ids
+                and default_operating_unit.mail_server_id
+            ):
+                return default_operating_unit.mail_server_id
+
+        return False
+
+    def _mail_get_operating_unit_label(self):
+        """Return operating unit label for logging purposes.
+
+        Examples:
+        - ``Operating Unit A`` for ``operating_unit_id``;
+        - ``Operating Unit A, Operating Unit B`` for ``operating_unit_ids``;
+        - ``no operating unit`` when no OU is set on the record.
+        """
+        self.ensure_one()
+        if "operating_unit_id" in self._fields and self.operating_unit_id:
+            return self.operating_unit_id.display_name
+        if "operating_unit_ids" in self._fields and self.operating_unit_ids:
+            return ", ".join(self.operating_unit_ids.mapped("display_name"))
+        return "no operating unit"

--- a/mail_operating_unit/models/operating_unit.py
+++ b/mail_operating_unit/models/operating_unit.py
@@ -8,3 +8,11 @@ class OperatingUnit(models.Model):
     _inherit = "operating.unit"
 
     alias_domain_id = fields.Many2one("mail.alias.domain", string="Alias Domain")
+    mail_server_id = fields.Many2one(
+        comodel_name="ir.mail_server",
+        string="Outgoing Mail Server",
+        help=(
+            "Preferred outgoing mail server for emails sent for records "
+            "belonging to this operating unit."
+        ),
+    )

--- a/mail_operating_unit/readme/CONFIGURE.md
+++ b/mail_operating_unit/readme/CONFIGURE.md
@@ -1,4 +1,9 @@
 To configure this module, you need to:
 
-- Assign *Alias Domain* to an Operating Unit.
-- Assign *Operating Unit* to an Email Template
+- Assign an *Alias Domain* to each Operating Unit that should use a specific email domain.
+- Assign an *Operating Unit* to an Email Template when emails sent from that template must use the alias domain of that operating unit.
+- Optionally assign an *Outgoing Mail Server* to an Operating Unit when emails should be routed through a specific SMTP server.
+
+When no operating unit is defined on the template or on the target record, the standard Odoo alias domain behavior is applied.
+
+When no unambiguous Operating Unit mail server can be determined, the standard Odoo outgoing mail server selection is applied.

--- a/mail_operating_unit/readme/CONTRIBUTORS.md
+++ b/mail_operating_unit/readme/CONTRIBUTORS.md
@@ -1,2 +1,3 @@
 - Vincent Van Rossem \<<vincent.vanrossem@camptocamp.com>\>
 - Italo Lopes \<<italo.lopes@camptocamp.com>\>
+- Maksym Yankin \<<maksym.yankin@camptocamp.com>\>

--- a/mail_operating_unit/readme/DESCRIPTION.md
+++ b/mail_operating_unit/readme/DESCRIPTION.md
@@ -1,1 +1,7 @@
-This module allows to link an Email Domain to an Operating Unit.
+This module allows companies working with multiple Operating Units to send emails with the appropriate email domain and, optionally, the appropriate outgoing mail server depending on the Operating Unit context.
+
+It lets you define an Alias Domain on an Operating Unit and use that domain automatically when emails are generated from templates or records linked to that Operating Unit.
+
+It also allows you to define an Outgoing Mail Server on an Operating Unit and automatically route emails through that server when no mail server is explicitly defined on the email template.
+
+This is especially useful in multi-brand or multi-entity environments where each Operating Unit must send emails using its own domain and SMTP server, while still keeping the standard Odoo behavior as a fallback when no specific Operating Unit configuration can be determined.

--- a/mail_operating_unit/static/description/index.html
+++ b/mail_operating_unit/static/description/index.html
@@ -375,7 +375,20 @@ ul.auto-toc {
 !! source digest: sha256:0d75996cd4f80bc86021744bc22b21bf200a8cbe74f7b75bcc71ea8fa8bca530
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! -->
 <p><a class="reference external image-reference" href="https://odoo-community.org/page/development-status"><img alt="Beta" src="https://img.shields.io/badge/maturity-Beta-yellow.png" /></a> <a class="reference external image-reference" href="http://www.gnu.org/licenses/lgpl-3.0-standalone.html"><img alt="License: LGPL-3" src="https://img.shields.io/badge/license-LGPL--3-blue.png" /></a> <a class="reference external image-reference" href="https://github.com/OCA/operating-unit/tree/17.0/mail_operating_unit"><img alt="OCA/operating-unit" src="https://img.shields.io/badge/github-OCA%2Foperating--unit-lightgray.png?logo=github" /></a> <a class="reference external image-reference" href="https://translation.odoo-community.org/projects/operating-unit-17-0/operating-unit-17-0-mail_operating_unit"><img alt="Translate me on Weblate" src="https://img.shields.io/badge/weblate-Translate%20me-F47D42.png" /></a> <a class="reference external image-reference" href="https://runboat.odoo-community.org/builds?repo=OCA/operating-unit&amp;target_branch=17.0"><img alt="Try me on Runboat" src="https://img.shields.io/badge/runboat-Try%20me-875A7B.png" /></a></p>
-<p>This module allows to link an Email Domain to an Operating Unit.</p>
+<p>This module allows companies working with multiple Operating Units to
+send emails with the appropriate email domain and, optionally, the
+appropriate outgoing mail server depending on the Operating Unit
+context.</p>
+<p>It lets you define an Alias Domain on an Operating Unit and use that
+domain automatically when emails are generated from templates or records
+linked to that Operating Unit.</p>
+<p>It also allows you to define an Outgoing Mail Server on an Operating
+Unit and automatically route emails through that server when no mail
+server is explicitly defined on the email template.</p>
+<p>This is especially useful in multi-brand or multi-entity environments
+where each Operating Unit must send emails using its own domain and SMTP
+server, while still keeping the standard Odoo behavior as a fallback
+when no specific Operating Unit configuration can be determined.</p>
 <p><strong>Table of contents</strong></p>
 <div class="contents local topic" id="contents">
 <ul class="simple">
@@ -393,9 +406,17 @@ ul.auto-toc {
 <h2><a class="toc-backref" href="#toc-entry-1">Configuration</a></h2>
 <p>To configure this module, you need to:</p>
 <ul class="simple">
-<li>Assign <em>Alias Domain</em> to an Operating Unit.</li>
-<li>Assign <em>Operating Unit</em> to an Email Template</li>
+<li>Assign an <em>Alias Domain</em> to each Operating Unit that should use a
+specific email domain.</li>
+<li>Assign an <em>Operating Unit</em> to an Email Template when emails sent from
+that template must use the alias domain of that operating unit.</li>
+<li>Optionally assign an <em>Outgoing Mail Server</em> to an Operating Unit when
+emails should be routed through a specific SMTP server.</li>
 </ul>
+<p>When no operating unit is defined on the template or on the target
+record, the standard Odoo alias domain behavior is applied.</p>
+<p>When no unambiguous Operating Unit mail server can be determined, the
+standard Odoo outgoing mail server selection is applied.</p>
 </div>
 <div class="section" id="bug-tracker">
 <h2><a class="toc-backref" href="#toc-entry-2">Bug Tracker</a></h2>
@@ -418,6 +439,7 @@ If you spotted it first, help us to smash it by providing a detailed and welcome
 <ul class="simple">
 <li>Vincent Van Rossem &lt;<a class="reference external" href="mailto:vincent.vanrossem&#64;camptocamp.com">vincent.vanrossem&#64;camptocamp.com</a>&gt;</li>
 <li>Italo Lopes &lt;<a class="reference external" href="mailto:italo.lopes&#64;camptocamp.com">italo.lopes&#64;camptocamp.com</a>&gt;</li>
+<li>Maksym Yankin &lt;<a class="reference external" href="mailto:maksym.yankin&#64;camptocamp.com">maksym.yankin&#64;camptocamp.com</a>&gt;</li>
 </ul>
 </div>
 <div class="section" id="maintainers">

--- a/mail_operating_unit/tests/common.py
+++ b/mail_operating_unit/tests/common.py
@@ -1,8 +1,11 @@
 # Copyright 2024 Camptocamp SA
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
+from odoo_test_helper import FakeModelLoader
+
 from odoo.models import Command
 
+from odoo.addons.base.tests.common import BaseCommon
 from odoo.addons.operating_unit.tests.common import OperatingUnitCommon
 
 
@@ -10,19 +13,17 @@ class MailOperatingUnitCommon(OperatingUnitCommon):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        # Email Alias Domain
+        # Email Alias Domains
         cls.ou_alias_domain = cls.env.ref("mail_operating_unit.ou_alias_domain")
-        cls.b2c_alias_domain = cls.env.ref("mail_operating_unit.b2b_alias_domain")
-        cls.b2b_alias_domain = cls.env.ref("mail_operating_unit.b2c_alias_domain")
+        cls.b2c_alias_domain = cls.env.ref("mail_operating_unit.b2c_alias_domain")
+        cls.b2b_alias_domain = cls.env.ref("mail_operating_unit.b2b_alias_domain")
         cls.default_alias_domain = cls.env["mail.alias.domain"].create(
             {"name": "default.com"}
         )
         # Company
         cls.company.write({"alias_domain_id": cls.default_alias_domain.id})
         # Users
-        # Create User 3 with Main OU and group_multi_operating_unit
         cls.user3 = cls._create_user("user_3", cls.grp_ou_multi, cls.company, cls.ou1)
-        # Add following groups to user3: 'Contact Creation'; 'Internal User'
         cls.user3.write(
             {
                 "groups_id": [
@@ -31,4 +32,114 @@ class MailOperatingUnitCommon(OperatingUnitCommon):
                 ]
             }
         )
+        # Mail objects
         cls.channel_general = cls.env.ref("mail.channel_all_employees")
+        # Mail template used by template / alias-domain tests
+        cls.mail_template = cls.env["mail.template"].create(
+            {
+                "name": "Test Template",
+                "model_id": cls.env.ref("base.model_res_partner").id,
+                "subject": "Test",
+                "body_html": "Test",
+                "email_from": "admin@example.com",
+                "email_to": "{{ object.email or 'test@example.com' }}",
+            }
+        )
+
+
+class FakePartnerMailOperatingUnitCommon(BaseCommon):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        cls.loader = FakeModelLoader(cls.env, cls.__module__)
+        cls.loader.backup_registry()
+
+        from .models.fake_partner import FakePartner
+
+        cls.loader.update_registry((FakePartner,))
+
+        cls.fake_partner = cls.env["res.partner"].create(
+            {
+                "name": "Fake Partner",
+                "email": "fake@example.com",
+            }
+        )
+        cls.company = cls.env.ref("base.main_company")
+
+        # Alias domains
+        cls.operating_unit_alias_domain = cls.env["mail.alias.domain"].create(
+            {"name": "operating_unit.com"}
+        )
+        cls.other_alias_domain = cls.env["mail.alias.domain"].create(
+            {"name": "other.com"}
+        )
+        cls.default_alias_domain = cls.env["mail.alias.domain"].create(
+            {"name": "default.com"}
+        )
+        cls.company.write({"alias_domain_id": cls.default_alias_domain.id})
+
+        # Outgoing mail servers
+        cls.mail_server_1 = cls.env["ir.mail_server"].create(
+            {
+                "name": "Test SMTP 1",
+                "smtp_host": "smtp1.example.com",
+                "smtp_port": 587,
+            }
+        )
+        cls.mail_server_2 = cls.env["ir.mail_server"].create(
+            {
+                "name": "Test SMTP 2",
+                "smtp_host": "smtp2.example.com",
+                "smtp_port": 587,
+            }
+        )
+
+        # Operating units
+        cls.operating_unit = cls.env["operating.unit"].create(
+            {
+                "name": "Operating Unit",
+                "code": "OU",
+                "company_id": cls.company.id,
+                "partner_id": cls.company.partner_id.id,
+                "alias_domain_id": cls.operating_unit_alias_domain.id,
+                "mail_server_id": cls.mail_server_1.id,
+            }
+        )
+        cls.other_operating_unit = cls.env["operating.unit"].create(
+            {
+                "name": "Other Operating Unit",
+                "code": "OU2",
+                "company_id": cls.company.id,
+                "partner_id": cls.company.partner_id.id,
+                "alias_domain_id": cls.other_alias_domain.id,
+                "mail_server_id": cls.mail_server_2.id,
+            }
+        )
+        cls.shared_operating_unit = cls.env["operating.unit"].create(
+            {
+                "name": "Shared Operating Unit",
+                "code": "OU3",
+                "company_id": cls.company.id,
+                "partner_id": cls.company.partner_id.id,
+                "alias_domain_id": cls.other_alias_domain.id,
+                "mail_server_id": cls.mail_server_1.id,
+            }
+        )
+
+        # Template used for fake partner tests
+        cls.mail_template = cls.env["mail.template"].create(
+            {
+                "name": "Test Template",
+                "model_id": cls.env.ref("base.model_res_partner").id,
+                "subject": "Test",
+                "body_html": "Test",
+                "email_from": "admin@example.com",
+                "email_to": "{{ object.email or 'test@example.com' }}",
+                "auto_delete": False,
+            }
+        )
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.loader.restore_registry()
+        super().tearDownClass()

--- a/mail_operating_unit/tests/models/fake_partner.py
+++ b/mail_operating_unit/tests/models/fake_partner.py
@@ -10,3 +10,10 @@ class FakePartner(models.Model):
     _description = "Fake Partner"
 
     operating_unit_id = fields.Many2one("operating.unit", string="Operating Unit")
+    operating_unit_ids = fields.Many2many(
+        comodel_name="operating.unit",
+        relation="fake_partner_operating_unit_rel",
+        column1="partner_id",
+        column2="operating_unit_id",
+        string="Operating Units",
+    )

--- a/mail_operating_unit/tests/test_fake_partner_mail_operating_unit.py
+++ b/mail_operating_unit/tests/test_fake_partner_mail_operating_unit.py
@@ -1,45 +1,14 @@
 # Copyright 2024 Camptocamp SA
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 
-from odoo_test_helper import FakeModelLoader
+from odoo.models import Command
 
-from odoo.addons.base.tests.common import BaseCommon
+from .common import FakePartnerMailOperatingUnitCommon
 
 
-class MailOperatingUnitCommon(BaseCommon):
-    @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
-        cls.loader = FakeModelLoader(cls.env, cls.__module__)
-        cls.loader.backup_registry()
-
-        from .models.fake_partner import FakePartner
-
-        cls.loader.update_registry((FakePartner,))
-
-        cls.fake_partner = cls.env["res.partner"].create({"name": "Fake Partner"})
-        cls.company = cls.env.ref("base.main_company")
-        cls.operating_unit_alias_domain = cls.env["mail.alias.domain"].create(
-            {"name": "operating_unit.com"}
-        )
-        cls.operating_unit = cls.env["operating.unit"].create(
-            {
-                "name": "Operating Unit",
-                "code": "OU",
-                "company_id": cls.company.id,
-                "partner_id": cls.company.partner_id.id,
-                "alias_domain_id": cls.operating_unit_alias_domain.id,
-            }
-        )
-
-    @classmethod
-    def tearDownClass(cls):
-        cls.loader.restore_registry()
-        super().tearDownClass()
-
-    def test_mail_thread_with_operating_unit(self):
-        """
-        Test mail.thread with operating_unit_id field set.
+class TestFakePartnerMailOperatingUnit(FakePartnerMailOperatingUnitCommon):
+    def test_00_mail_thread_with_operating_unit(self):
+        """Test mail.thread with operating_unit_id field set.
 
         Ensures that when a mail.thread (represented here by a fake partner)
         is associated with an operating unit,
@@ -49,27 +18,171 @@ class MailOperatingUnitCommon(BaseCommon):
         self.fake_partner.write({"operating_unit_id": self.operating_unit.id})
         message = self.fake_partner.message_post(body="Test")
         self.assertEqual(
-            message.record_alias_domain_id, self.operating_unit_alias_domain
+            message.record_alias_domain_id,
+            self.operating_unit_alias_domain,
         )
 
-    def test_mail_thread_with_false_operating_unit(self):
-        """
-        Test mail.thread with operating_unit_id field set to False.
+    def test_01_mail_thread_with_false_operating_unit(self):
+        """Test mail.thread with operating_unit_id field set to False.
 
         Ensures that when a mail.thread (represented here by a fake partner)
         has no operating unit associated,
         the default mail alias domain is used for the mail sent through this thread.
         """
-        self.fake_partner.write({"operating_unit_id": False})
-        self.assertFalse(self.fake_partner.operating_unit_id)
-
-        default_alias_domain = self.env["mail.alias.domain"].create(
-            {"name": "default.com"}
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [Command.clear()],
+            }
         )
-        self.company.write({"alias_domain_id": default_alias_domain.id})
-        self.assertEqual(self.company.alias_domain_id, default_alias_domain)
+        self.assertFalse(self.fake_partner.operating_unit_id)
         user_root = self.env.ref("base.user_admin")
         user_root.operating_unit_ids.unlink()
         self.assertFalse(user_root.operating_unit_ids)
         message = self.fake_partner.message_post(body="Test")
-        self.assertEqual(message.record_alias_domain_id.name, default_alias_domain.name)
+        self.assertEqual(message.record_alias_domain_id, self.default_alias_domain)
+
+    def test_02_mail_thread_with_single_operating_unit_ids(self):
+        """Use the record alias domain when one ``operating_unit_ids`` is set."""
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [Command.set([self.operating_unit.id])],
+            }
+        )
+        message = self.fake_partner.message_post(body="Test")
+        self.assertEqual(
+            message.record_alias_domain_id,
+            self.operating_unit_alias_domain,
+        )
+
+    def test_03_mail_thread_with_multiple_operating_unit_ids(self):
+        """Fallback when multiple ``operating_unit_ids`` are set."""
+        user_root = self.env.ref("base.user_admin")
+        user_root.operating_unit_ids.unlink()
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [
+                    Command.set([self.operating_unit.id, self.other_operating_unit.id])
+                ],
+            }
+        )
+        message = self.fake_partner.message_post(body="Test")
+        self.assertEqual(message.record_alias_domain_id, self.default_alias_domain)
+
+    def test_04_mail_thread_with_single_operating_unit_ids_without_alias_domain(self):
+        """Fallback when the single record OU has no alias domain."""
+        user_root = self.env.ref("base.user_admin")
+        user_root.operating_unit_ids.unlink()
+        self.other_operating_unit.alias_domain_id = False
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [Command.set([self.other_operating_unit.id])],
+            }
+        )
+        message = self.fake_partner.message_post(body="Test")
+
+        self.assertEqual(message.record_alias_domain_id, self.default_alias_domain)
+
+    def test_05_template_mail_server_keeps_priority(self):
+        """Template mail server must remain the highest priority."""
+        self.mail_template.write({"mail_server_id": self.mail_server_2.id})
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [Command.set([self.operating_unit.id])],
+            }
+        )
+        mail_id = self.mail_template.send_mail(self.fake_partner.id, force_send=False)
+        mail = self.env["mail.mail"].browse(mail_id)
+        self.assertEqual(mail.mail_server_id, self.mail_server_2)
+
+    def test_06_record_single_operating_unit_ids_mail_server(self):
+        """Use the record OU mail server when exactly one OU is set."""
+        self.mail_template.write({"mail_server_id": False})
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [Command.set([self.operating_unit.id])],
+            }
+        )
+        mail_id = self.mail_template.send_mail(
+            self.fake_partner.id,
+            force_send=False,
+        )
+        mail = self.env["mail.mail"].browse(mail_id)
+        mail.send()
+        self.assertEqual(mail.mail_server_id, self.mail_server_1)
+
+    def test_07_record_operating_unit_ids_shared_mail_server(self):
+        """Use the shared server when all record OUs point to the same one."""
+        self.mail_template.write({"mail_server_id": False})
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [
+                    Command.set([self.operating_unit.id, self.shared_operating_unit.id])
+                ],
+            }
+        )
+        mail_id = self.mail_template.send_mail(
+            self.fake_partner.id,
+            force_send=False,
+        )
+        mail = self.env["mail.mail"].browse(mail_id)
+        mail.send()
+        self.assertEqual(mail.mail_server_id, self.mail_server_1)
+
+    def test_08_record_operating_unit_ids_different_mail_servers(self):
+        """Fallback when record OUs do not share the same outgoing mail server."""
+        self.mail_template.write({"mail_server_id": False})
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [
+                    Command.set([self.operating_unit.id, self.other_operating_unit.id])
+                ],
+            }
+        )
+        mail_id = self.mail_template.send_mail(self.fake_partner.id, force_send=False)
+        mail = self.env["mail.mail"].browse(mail_id)
+        self.assertFalse(mail.mail_server_id)
+
+    def test_09_record_operating_unit_ids_different_servers_use_default_ou(self):
+        """Use the current user's default OU when record OUs have different servers."""
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [
+                    Command.set([self.operating_unit.id, self.other_operating_unit.id])
+                ],
+            }
+        )
+        # ``res.users._get_default_operating_unit()`` relies on
+        # ``default_operating_unit_id`` first, then on
+        # ``assigned_operating_unit_ids`` as fallback.
+        # Set both explicitly to make the test deterministic.
+        self.env.user.write(
+            {
+                "assigned_operating_unit_ids": [
+                    Command.set([self.operating_unit.id, self.other_operating_unit.id])
+                ],
+                "default_operating_unit_id": self.other_operating_unit.id,
+            }
+        )
+        self.assertEqual(
+            self.env.user._get_default_operating_unit(),
+            self.other_operating_unit,
+        )
+        mail_id = self.mail_template.send_mail(
+            self.fake_partner.id,
+            force_send=False,
+        )
+        mail = self.env["mail.mail"].browse(mail_id)
+        # When multiple OUs are present on the record
+        # and they do not share the same server,
+        # the default OU of the current user is used.
+        mail.send()
+        self.assertEqual(mail.mail_server_id, self.mail_server_2)

--- a/mail_operating_unit/tests/test_mail_operating_unit.py
+++ b/mail_operating_unit/tests/test_mail_operating_unit.py
@@ -1,63 +1,46 @@
 # Copyright 2024 Camptocamp SA
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+from odoo.models import Command
 
 from .common import MailOperatingUnitCommon
 
 
 class TestMailOperatingUnit(MailOperatingUnitCommon):
-    def test_mail_template_with_operating_unit(self):
-        """
-        Test mail.template with operating_unit_id field set.
+    def test_00_mail_template_with_operating_unit(self):
+        """Test mail.template with operating_unit_id field set.
 
         Ensures that when a mail is sent using a mail.template
         with an operating_unit_id,
         the mail.alias.domain associated with that operating unit is correctly used.
         """
-        template = self.env["mail.template"].create(
-            {
-                "name": "Test Template",
-                "model_id": self.env.ref("base.model_res_partner").id,
-                "subject": "Test",
-                "body_html": "Test",
-                "operating_unit_id": self.ou1.id,
-            }
-        )
-        mail_id = template.send_mail(self.partner1.id)
+        self.mail_template.write({"operating_unit_id": self.ou1.id})
+        mail_id = self.mail_template.send_mail(self.partner1.id)
         mail = self.env["mail.mail"].browse(mail_id)
         self.assertEqual(mail.record_alias_domain_id, self.ou_alias_domain)
 
-    def test_user_single_operating_unit(self):
-        """
-        Test for user with a single operating unit.
-
+    def test_01_user_single_operating_unit(self):
+        """Test for user with a single operating unit.
         Ensures that when a user with exactly one operating unit sends an email,
         the mail.alias.domain associated with that operating unit is used.
         """
         self.b2c.write({"alias_domain_id": self.b2c_alias_domain.id})
-        self.user3.write({"operating_unit_ids": [(6, 0, [self.b2c.id])]})
-
-        message = self.channel_general.with_user(self.user3).message_post(
-            body="Test",
-        )
+        self.user3.write({"operating_unit_ids": [Command.set([self.b2c.id])]})
+        message = self.channel_general.with_user(self.user3).message_post(body="Test")
         self.assertEqual(message.record_alias_domain_id, self.b2c_alias_domain)
 
-    def test_user_no_operating_units(self):
-        """
-        Test for user with no operating units.
+    def test_02_user_no_operating_units(self):
+        """Test for user with no operating units.
 
         Ensures that when a user has no operating units,
         the default mail.alias.domain computation
         is used for emails sent by the user.
         """
         self.user3.write({"operating_unit_ids": False})
-        message = self.channel_general.with_user(self.user3).message_post(
-            body="Test",
-        )
+        message = self.channel_general.with_user(self.user3).message_post(body="Test")
         self.assertEqual(message.record_alias_domain_id, self.default_alias_domain)
 
-    def test_user_multiple_operating_units_same_domain(self):
-        """
-        Test for user with multiple operating units having the same domain.
+    def test_03_user_multiple_operating_units_same_domain(self):
+        """Test for user with multiple operating units having the same domain.
 
         Ensures that when a user belongs to multiple operating units
         that all have the same mail.alias.domain,
@@ -65,22 +48,21 @@ class TestMailOperatingUnit(MailOperatingUnitCommon):
         """
         self.b2b.write({"alias_domain_id": self.ou_alias_domain.id})
         self.b2c.write({"alias_domain_id": self.ou_alias_domain.id})
-        self.user3.write({"operating_unit_ids": [(6, 0, [self.b2b.id, self.b2c.id])]})
-        message = self.channel_general.with_user(self.user3).message_post(
-            body="Test",
+        self.user3.write(
+            {"operating_unit_ids": [Command.set([self.b2b.id, self.b2c.id])]}
         )
+        message = self.channel_general.with_user(self.user3).message_post(body="Test")
         self.assertEqual(message.record_alias_domain_id, self.ou_alias_domain)
 
-    def test_user_multiple_operating_units_different_domains(self):
-        """
-        Test for user with multiple operating units having different domains.
+    def test_04_user_multiple_operating_units_different_domains(self):
+        """Test for user with multiple operating units having different domains.
 
         Ensures that when a user is associated with multiple operating units
         with different mail.alias.domain,
         the default computation for mail.alias.domain is used.
         """
-        self.user3.write({"operating_unit_ids": [(6, 0, [self.b2b.id, self.b2c.id])]})
-        message = self.channel_general.with_user(self.user3).message_post(
-            body="Test",
+        self.user3.write(
+            {"operating_unit_ids": [Command.set([self.b2b.id, self.b2c.id])]}
         )
+        message = self.channel_general.with_user(self.user3).message_post(body="Test")
         self.assertEqual(message.record_alias_domain_id, self.default_alias_domain)

--- a/mail_operating_unit/views/operating_unit.xml
+++ b/mail_operating_unit/views/operating_unit.xml
@@ -8,6 +8,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="alias_domain_id" />
+                <field name="mail_server_id" />
             </xpath>
         </field>
     </record>
@@ -17,6 +18,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='company_id']" position="after">
                 <field name="alias_domain_id" optional="show" />
+                <field name="mail_server_id" optional="show" />
             </xpath>
         </field>
     </record>
@@ -26,6 +28,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='code']" position="after">
                 <field name="alias_domain_id" string="Email Domain" />
+                <field name="mail_server_id" string="Outgoing Mail Server" />
             </xpath>
         </field>
     </record>


### PR DESCRIPTION
This PR extends `mail_operating_unit` in two ways.

First, it adds support for records using `operating_unit_ids` in addition to `operating_unit_id`. When a `mail.thread` record has exactly one operating unit in `operating_unit_ids` and this operating unit has an alias domain, the module now uses that alias domain for mail generation. This covers models such as `res.partner`, which store operating units on a many2many field and are used by reminder emails. The existing behavior for `operating_unit_id` remains unchanged.

Second, it adds optional outgoing mail server routing based on the operating unit. When enabled in `General Settings`, and when no outgoing mail server is explicitly defined on the email template, the module selects the mail server from the target record:

- from `operating_unit_id` when it has a configured mail server;
- from `operating_unit_ids` when all operating units share the same mail server.

This allows emails such as reminders or invoices to be routed automatically through the proper SMTP server for each operating unit, while preserving template priority and falling back to standard Odoo behavior when no unambiguous operating-unit configuration can be determined.