### PR TITLE
[14.0][FIX] stock_operating_unit: allow manager to select OUs

### DIFF
--- a/stock_operating_unit/model/stock_rule.py
+++ b/stock_operating_unit/model/stock_rule.py
@@ -11,5 +11,4 @@ class StockRule(models.Model):
     operating_unit_id = fields.Many2one(
         "operating.unit",
         related="warehouse_id.operating_unit_id",
-        domain="[('user_ids', '=', uid)]",
     )

--- a/stock_operating_unit/view/stock.xml
+++ b/stock_operating_unit/view/stock.xml
@@ -12,8 +12,7 @@
                 <field
                     name="operating_unit_id"
                     options="{'no_create': True}"
-                    domain="[('company_id','=', company_id),
-                       ('user_ids', 'in', uid)]"
+                    domain="[('company_id','=', company_id)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -27,7 +26,6 @@
             <field name="partner_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -42,8 +40,7 @@
                 <field
                     name="operating_unit_id"
                     options="{'no_create': True}"
-                    domain="[('company_id','=', company_id),
-                       ('user_ids', 'in', uid)]"
+                    domain="[('company_id','=', company_id)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -57,7 +54,6 @@
             <field name="usage" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -71,7 +67,6 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -85,7 +80,6 @@
             <field name="origin" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -103,15 +97,14 @@
                 <field
                     name="operating_unit_id"
                     options="{'no_create': True}"
-                    domain="[('company_id','=', company_id),
-                       ('user_ids', 'in', uid)]"
+                    domain="[('company_id','=', company_id)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </xpath>
             <field name="picking_type_id" position="attributes">
                 <attribute
                     name="domain"
-                >[('warehouse_id.operating_unit_id.user_ids', 'in', uid)]</attribute>
+                >[('warehouse_id.operating_unit_id', 'in', [operating_unit_id, False])]</attribute>
             </field>
         </field>
     </record>
@@ -123,7 +116,6 @@
             <field name="product_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -145,14 +137,12 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
             <field name="location_dest_id" position="after">
                 <field
                     name="operating_unit_dest_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -166,14 +156,12 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
             <field name="location_dest_id" position="after">
                 <field
                     name="operating_unit_dest_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -187,14 +175,12 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
             <field name="location_dest_id" position="after">
                 <field
                     name="operating_unit_dest_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -208,14 +194,12 @@
             <field name="location_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
             <field name="location_dest_id" position="after">
                 <field
                     name="operating_unit_dest_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>


### PR DESCRIPTION
Checking the field `user_ids` of `operating.unit` to set a domain is both unnecessary (record rules already filter the correct records) and wrong/obsolete because users who are managers of all OUs don'the appear in the `user_ids` field.

Alternative to https://github.com/OCA/operating-unit/pull/849