### PR TITLE
[14.0][FIX] purchase_operating_unit: allow manager to select OUs

### DIFF
--- a/purchase_operating_unit/views/purchase_order_line_view.xml
+++ b/purchase_operating_unit/views/purchase_order_line_view.xml
@@ -8,7 +8,6 @@
             <field name="partner_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -22,7 +21,6 @@
             <field name="price_unit" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -44,7 +42,6 @@
             <field name="partner_id" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>

--- a/purchase_operating_unit/views/purchase_order_view.xml
+++ b/purchase_operating_unit/views/purchase_order_view.xml
@@ -8,7 +8,6 @@
             <field name="origin" position="after">
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>
@@ -22,12 +21,10 @@
             <field name="partner_ref" position="after">
                 <field
                     name="requesting_operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
                 <field
                     name="operating_unit_id"
-                    domain="[('user_ids', 'in', uid)]"
                     groups="operating_unit.group_multi_operating_unit"
                 />
             </field>


### PR DESCRIPTION
Checking the field user_ids of operating.unit to set a domain is both unnecessary (record rules already filter the correct records) and wrong/obsolete because users who are managers of all OUs don't appear in the user_ids field.

Cf. the same fix in #850 