### PR TITLE
[18.0][FIX] sales_team_operating_unit: Add default company_id

### DIFF
--- a/sales_team_operating_unit/models/crm_team.py
+++ b/sales_team_operating_unit/models/crm_team.py
@@ -2,7 +2,7 @@
 # Copyright 2017-TODAY Serpent Consulting Services Pvt. Ltd.
 #   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class CrmTeam(models.Model):
@@ -13,3 +13,11 @@ class CrmTeam(models.Model):
         default=lambda self: self.env["res.users"]._get_default_operating_unit(),
         check_company=True,
     )
+
+    @api.model
+    def default_get(self, fields_list):
+        res = super().default_get(fields_list)
+        if res.get("operating_unit_id"):
+            operating_unit = self.env["operating.unit"].browse(res["operating_unit_id"])
+            res["company_id"] = operating_unit.company_id.id
+        return res

--- a/sales_team_operating_unit/tests/test_crm_team_operating_unit.py
+++ b/sales_team_operating_unit/tests/test_crm_team_operating_unit.py
@@ -2,7 +2,7 @@
 # Copyright 2017-TODAY Serpent Consulting Services Pvt. Ltd.
 #   (<http://www.serpentcs.com>)
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
-from odoo.tests import common
+from odoo.tests import Form, common
 
 
 class TestSaleTeamOperatingUnit(common.TransactionCase):
@@ -68,6 +68,18 @@ class TestSaleTeamOperatingUnit(common.TransactionCase):
     def test_crm_team(self):
         # User 2 is only assigned to B2C Operating Unit, and cannot
         # access CRM teams for Main Operating Unit.
+
+        with Form(
+            self.crm_team_model, view="sales_team.crm_team_view_form"
+        ) as crm_form:
+            crm_form.name = "Test CRM Team"
+            crm_form.operating_unit_id = self.ou1
+            self.assertEqual(
+                crm_form.company_id,
+                self.ou1.company_id,
+                "Company should be same as Operating Unit company",
+            )
+
         team = self.crm_team_model.with_user(self.user2.id).search(
             [("id", "=", self.team1.id), ("operating_unit_id", "=", self.ou1.id)]
         )


### PR DESCRIPTION
Adding default company to resolve incompatible records error coming up while creating sales team, when a user doesn't have multi-company access.

> [!WARNING]
>  <img width="694" height="260" alt="image" src="https://github.com/user-attachments/assets/1f6a64d8-dd8b-48db-9669-e8e6467a788f" />
