### PR TITLE
[17.0][FIX] mail_operating_unit: assign OU mail server before SMTP session grouping

### DIFF
--- a/mail_operating_unit/models/mail_mail.py
+++ b/mail_operating_unit/models/mail_mail.py
@@ -12,28 +12,21 @@ class MailMail(models.Model):
 
     operating_unit_id = fields.Many2one("operating.unit", string="Operating Unit")
 
-    def _send(
-        self,
-        auto_commit=False,
-        raise_exception=False,
-        smtp_session=None,
-        alias_domain_id=False,
-    ):
-        # OVERRIDE: to assign an OU mail server when no explicit mail server is set.
+    def _resolve_operating_unit_mail_server(self):
+        """Assign the OU outgoing mail server on mails that have none.
 
-        # Template mail server keeps the highest priority,
-        # because it is already stored on ``mail.mail.mail_server_id``
-        # before this method is called.
-        no_mail_server_mails = self.filtered(
+        Iterates over mails without a ``mail_server_id`` that are linked to a
+        record, and assigns the OU mail server when one can be resolved.
+        Mails that already have a server set (e.g. from a template) are left
+        untouched.
+        """
+        no_server_mails = self.filtered(
             lambda mail: not mail.mail_server_id and mail.model and mail.res_id
         )
-        for mail in no_mail_server_mails:
-            # Check if the related record actually exists,
-            # as the mail could be linked to a deleted record.
+        for mail in no_server_mails:
             record = self.env[mail.model].browse(mail.res_id).exists()
             if not record:
                 continue
-
             if mail_server := record._mail_get_operating_unit_mail_server():
                 mail.write({"mail_server_id": mail_server.id})
                 # Log the information about the resolved mail server
@@ -56,6 +49,26 @@ class MailMail(models.Model):
                     record.id,
                 )
 
+    def _split_by_mail_configuration(self):
+        # OVERRIDE: pre-assign the OU mail server before grouping so the SMTP
+        # session is opened on the correct server from the start.
+        # See ``_resolve_operating_unit_mail_server()`` for the resolution logic.
+        self._resolve_operating_unit_mail_server()
+        return super()._split_by_mail_configuration()
+
+    def _send(
+        self,
+        auto_commit=False,
+        raise_exception=False,
+        smtp_session=None,
+        alias_domain_id=False,
+    ):
+        # SAFETY NET: ``_split_by_mail_configuration()`` already pre-assigns
+        # ``mail_server_id`` from the OU before this method is called through the
+        # normal ``send()`` flow, so this will typically be a no-op.
+        # Kept as a fallback for any direct call to ``_send()`` that bypasses
+        # ``_split_by_mail_configuration()``.
+        self._resolve_operating_unit_mail_server()
         return super()._send(
             auto_commit=auto_commit,
             raise_exception=raise_exception,

--- a/mail_operating_unit/tests/__init__.py
+++ b/mail_operating_unit/tests/__init__.py
@@ -1,2 +1,3 @@
 from . import test_fake_partner_mail_operating_unit
 from . import test_mail_operating_unit
+from . import test_smtp_server_selection

--- a/mail_operating_unit/tests/test_smtp_server_selection.py
+++ b/mail_operating_unit/tests/test_smtp_server_selection.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Camptocamp SA
+# License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
+
+from odoo.models import Command
+
+from odoo.addons.base.tests.common import MockSmtplibCase
+
+from .common import FakePartnerMailOperatingUnitCommon
+
+
+class TestSmtpServerSelection(FakePartnerMailOperatingUnitCommon, MockSmtplibCase):
+    """Verify which SMTP server is actually used when sending mail with an OU.
+
+    Companion to ``TestFakePartnerMailOperatingUnit``, which tests the OU
+    resolution logic and the ``mail.mail.mail_server_id`` DB field assignment.
+    That class does not verify which SMTP server is actually connected to,
+    because Odoo's test mode makes ``ir.mail_server.connect()`` return ``None``
+    immediately regardless of the ``mail_server_id`` argument.
+
+    This class uses ``MockSmtplibCase`` to disable that shortcut and intercept
+    the real arguments passed to ``connect()``, making it possible to assert
+    that the SMTP session is opened on the expected server.
+
+    The scenario under test is a priority conflict: two outgoing mail servers
+    coexist, one being a high-priority catch-all (lower ``sequence``) that
+    ``_find_mail_server()`` would select by default, and a lower-priority one
+    that is the OU's configured server.  The OU server must win.
+    """
+
+    def setUp(self):
+        super().setUp()
+        # mail_server_2: high-priority catch-all (sequence=1)
+        # mail_server_1: OU's server (sequence=10, lower priority)
+        self.mail_server_2.write({"sequence": 1})
+        self.mail_server_1.write({"sequence": 10})
+        self.mail_template.write({"mail_server_id": False})
+
+    def test_00_ou_server_used_before_smtp_grouping(self):
+        """When an OU is set, its mail server must be used for the SMTP session."""
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [Command.set([self.operating_unit.id])],
+            }
+        )
+        mail_id = self.mail_template.send_mail(self.fake_partner.id, force_send=False)
+        mail = self.env["mail.mail"].browse(mail_id)
+
+        with self.mock_smtplib_connection():
+            mail.send()
+
+        self.connect_mocked.assert_called_once()
+        _, call_kwargs = self.connect_mocked.call_args
+        self.assertEqual(
+            call_kwargs.get("mail_server_id"),
+            self.mail_server_1.id,
+            "SMTP session must be opened on the OU mail server, not the catch-all",
+        )
+        self.assertEqual(mail.mail_server_id, self.mail_server_1)
+
+    def test_01_no_ou_uses_default_server_selection(self):
+        """Without an OU, the standard server selection applies (catch-all wins)."""
+        self.fake_partner.write(
+            {
+                "operating_unit_id": False,
+                "operating_unit_ids": [Command.clear()],
+            }
+        )
+        mail_id = self.mail_template.send_mail(self.fake_partner.id, force_send=False)
+        mail = self.env["mail.mail"].browse(mail_id)
+
+        with self.mock_smtplib_connection():
+            mail.send()
+
+        self.connect_mocked.assert_called_once()
+        _, call_kwargs = self.connect_mocked.call_args
+        self.assertEqual(
+            call_kwargs.get("mail_server_id"),
+            self.mail_server_2.id,
+            "Without an OU, the highest-priority catch-all server must be used",
+        )


### PR DESCRIPTION
When multiple outgoing mail servers coexist, ``mail.mail.send()`` calls
``_split_by_mail_configuration()`` to group mails and open SMTP sessions
before delegating to ``_send()``.

At grouping time, ``mail_server_id`` is NULL on records whose server is
resolved from an operating unit, so ``_find_mail_server()`` picks a server
based on priority and from-filter rules, potentially selecting the wrong
one.

The existing override in ``_send()`` writes the correct server to the
database, but by then the SMTP session is already established on the wrong
server.

Extract the OU mail server resolution into a dedicated method
``_resolve_operating_unit_mail_server()`` and call it from a new
``_split_by_mail_configuration()`` override, so ``mail_server_id`` is set
before grouping occurs and the SMTP session is opened on the correct server
from the start.

The ``_send()`` override is kept as a safety net for direct calls that
bypass ``_split_by_mail_configuration()``.

Add ``test_smtp_server_selection.py`` which uses ``MockSmtplibCase`` to
assert which server is actually passed to ``connect()``, covering both the
OU case (OU server must win over a higher-priority catch-all) and the no-OU
case (standard server selection must still apply).