### PR TITLE
[FIX] sale_operating_unit_sequence: resolve operating unit from its d…

### DIFF
--- a/sale_operating_unit_sequence/models/sale_order.py
+++ b/sale_operating_unit_sequence/models/sale_order.py
@@ -15,9 +15,23 @@ class SaleOrder(models.Model):
         return super().create(vals)
 
     @api.model
+    def _get_sequence_operating_unit_id(self, vals):
+        """Resolve the operating unit to use for sequence generation,
+        falling back to the field's default when it is missing from vals."""
+        if "operating_unit_id" in vals:
+            # Key present, even if falsy: the caller explicitly requested no
+            # operating unit, so do not override it with the default.
+            operating_unit_id = vals["operating_unit_id"]
+        else:
+            operating_unit_id = self.default_get(["operating_unit_id"]).get(
+                "operating_unit_id"
+            )
+        return operating_unit_id
+
+    @api.model
     def _update_sale_order_name(self, vals):
         """Update sale order name in vals if operating unit has a sequence."""
-        operating_unit_id = vals.get("operating_unit_id")
+        operating_unit_id = self._get_sequence_operating_unit_id(vals)
         if operating_unit_id:
             ou_id = self.env["operating.unit"].browse(operating_unit_id)
             name = ou_id._get_next_sale_order_number()

--- a/sale_operating_unit_sequence/tests/test_sale_operating_unit_sequence.py
+++ b/sale_operating_unit_sequence/tests/test_sale_operating_unit_sequence.py
@@ -20,3 +20,104 @@ class TestSaleOperatingUnitSequence(TransactionCase):
         so2 = so1.copy()
         so2_sequence = so2.name
         self.assertNotEqual(so1_sequence, so2_sequence, "Sequences are different")
+
+    def test_create_sequence_operating_unit_id_absent_from_vals(self):
+        """The OU's sale sequence must apply even when operating_unit_id is
+        absent from create() vals - e.g. because the field is hidden for a
+        user without the "Multiple Operating Units" permission, or because
+        the order was created programmatically without passing it. In that
+        case it must be resolved from the field's own default instead."""
+        sequence = self.env["ir.sequence"].create(
+            {
+                "name": "OU Sale Sequence",
+                "code": "sale.order.ou.test",
+                "prefix": "OUSO-",
+                "padding": 3,
+            }
+        )
+        operating_unit = self.env["operating.unit"].create(
+            {
+                "name": "Test OU",
+                "code": "TESTOU",
+                "partner_id": self.customer.id,
+                "sale_sequence_id": sequence.id,
+            }
+        )
+        user = self.env["res.users"].create(
+            {
+                "name": "Single OU Salesperson",
+                "login": "single_ou_salesperson_base@example.com",
+                "email": "single_ou_salesperson_base@example.com",
+                "groups_id": [
+                    (4, self.env.ref("sales_team.group_sale_salesman").id),
+                ],
+                "assigned_operating_unit_ids": [(6, 0, [operating_unit.id])],
+                "default_operating_unit_id": operating_unit.id,
+            }
+        )
+        self.assertFalse(
+            user.has_group("operating_unit.group_multi_operating_unit"),
+            "Test user must not have the Multiple Operating Units permission",
+        )
+        so = (
+            self.sale_model.with_user(user)
+            .with_company(operating_unit.company_id)
+            .create(
+                {
+                    "partner_id": self.customer.id,
+                    # Avoid interference from the unrelated team/OU
+                    # consistency constraint (sale_operating_unit): this test
+                    # is only about the sequence/OU default resolution.
+                    "team_id": False,
+                }
+            )
+        )
+        self.assertEqual(so.operating_unit_id, operating_unit)
+        self.assertTrue(so.name.startswith("OUSO-"))
+
+    def test_create_sequence_operating_unit_id_explicit_false(self):
+        """When the caller explicitly passes operating_unit_id=False, that
+        must be respected as "no operating unit" rather than treated the
+        same as the key being absent (which would fall back to the field's
+        default)."""
+        sequence = self.env["ir.sequence"].create(
+            {
+                "name": "OU Sale Sequence",
+                "code": "sale.order.ou.explicit.false.test",
+                "prefix": "OUFALSE-",
+                "padding": 3,
+            }
+        )
+        operating_unit = self.env["operating.unit"].create(
+            {
+                "name": "Test OU",
+                "code": "TESTOU2",
+                "partner_id": self.customer.id,
+                "sale_sequence_id": sequence.id,
+            }
+        )
+        user = self.env["res.users"].create(
+            {
+                "name": "Single OU Salesperson",
+                "login": "single_ou_salesperson_false@example.com",
+                "email": "single_ou_salesperson_false@example.com",
+                "groups_id": [
+                    (4, self.env.ref("sales_team.group_sale_salesman").id),
+                ],
+                "assigned_operating_unit_ids": [(6, 0, [operating_unit.id])],
+                "default_operating_unit_id": operating_unit.id,
+            }
+        )
+        so = (
+            self.sale_model.with_user(user)
+            .with_company(operating_unit.company_id)
+            .create(
+                {
+                    "partner_id": self.customer.id,
+                    "team_id": False,
+                    "operating_unit_id": False,
+                }
+            )
+        )
+        self.assertFalse(so.operating_unit_id)
+        self.assertFalse(so.name.startswith("OUFALSE-"))


### PR DESCRIPTION
…efault when absent from create vals

operating_unit_id is hidden in the view for users without the Multiple Operating Units permission, so the client never submits it and it is absent from vals on create. The same is true for any programmatic/API create that omits it. _update_sale_order_name only looked at vals.get("operating_unit_id"), so in both cases it silently did nothing and the operating unit's sale sequence was never applied, even though the record still received that operating unit via its field default a moment later (in base create(), which merges defaults after this hook runs).

Add _get_sequence_operating_unit_id(), which falls back to self.default_get(["operating_unit_id"]) when vals has no operating unit, so the sequence is generated consistently for UI and backend/API creates.